### PR TITLE
Remove build tools from production Docker image stage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,12 +18,14 @@ COPY . .
 RUN CGO_ENABLED=1 GOOS=linux go build -o recommender
 
 # Use a minimal alpine image for the final stage
-FROM alpine:latest
+FROM alpine:3.21
 
 WORKDIR /app
 
-# Install SQLite and create non-root user
-RUN apk add --no-cache gcc musl-dev git sqlite
+# Only install runtime dependencies.
+# gcc, musl-dev, and git are compile-time tools — they are NOT needed
+# to run an already-compiled binary and should not ship in production.
+RUN apk add --no-cache ca-certificates sqlite-libs
 RUN adduser -D -u 1000 appuser && \
   mkdir -p /data && \
   chown -R appuser:appuser /data && \
@@ -32,7 +34,7 @@ RUN adduser -D -u 1000 appuser && \
   chown appuser:appuser /data/recommender.db && \
   chmod 777 /data/recommender.db
 
-# Copy the binary and templates from builder
+# Copy the binary from builder
 COPY --from=builder /app/recommender .
 
 # Set environment variables


### PR DESCRIPTION
## Problem

The production (final) Docker stage installed **compile-time tools** that have no runtime purpose:

```dockerfile
FROM alpine:latest
RUN apk add --no-cache gcc musl-dev git sqlite  # ← gcc, musl-dev, git not needed at runtime
```

This means the production container ships with:
- A C compiler (`gcc`) — allows attackers who gain code execution to compile exploits in-container
- C standard library development headers (`musl-dev`) — build infrastructure
- A full `git` installation — can be used to fetch payloads
- `alpine:latest` (unpinned) — non-reproducible base image

These are exclusively build-time dependencies. The already-compiled `recommender` binary only requires the SQLite shared library (`sqlite-libs`) to be present at runtime.

## Fix

- Remove `gcc`, `musl-dev`, `git` from the final stage
- Add `ca-certificates` for TLS connections
- Keep only `sqlite-libs` (the `.so` shared library the CGO binary links against)
- Pin `FROM alpine:latest` → `FROM alpine:3.21` for reproducible builds

Build-time dependencies remain in the `builder` stage where they belong.

## Testing

```bash
docker build -t recommender .
docker run --rm -e PORT=8080 -p 8080:8080 -v /tmp/data:/data recommender
# gcc should NOT be present:
docker run --rm recommender which gcc  # should fail
docker images recommender              # image should be significantly smaller
```

## Audit notes

| Area | Finding | Action |
|------|---------|--------|
| Dockerfile final stage | `gcc`, `musl-dev`, `git` in production image | **Fixed (this PR)** |
| Dockerfile final stage | `FROM alpine:latest` unpinned | **Fixed (this PR)** |
| Non-root user | Already configured (`appuser`) | No change needed |
| `go.mod` | Minimal dependencies | No action needed |
