### PR TITLE
Upgrade runtime base image from alpine:3.21 to alpine:3.22

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ COPY . .
 RUN CGO_ENABLED=1 GOOS=linux go build -o recommender
 
 # Use a minimal alpine image for the final stage
-FROM alpine:3.21
+FROM alpine:3.22
 
 WORKDIR /app
 


### PR DESCRIPTION
## Problem

The final runtime stage used `alpine:3.21` (released November 2024), which has been superseded by `alpine:3.22` (May 2025). Alpine 3.21 is missing security patches included in 3.22.

## Fix

```diff
-FROM alpine:3.21
+FROM alpine:3.22
```

Single-line bump. The non-root user (`appuser`, UID 1000) and other container hygiene were already correctly implemented.

## Testing

```bash
docker build -t recommender-test .
docker run --rm recommender-test id
# uid=1000(appuser) gid=1000(appuser) ...
```

## Audit Note

**Reviewed**: Dockerfile, go.mod, main.go, handlers/, models/  
**Found & fixed**: outdated alpine:3.21 base image  
**Already good**: non-root user (appuser, UID 1000), multi-stage build, separate /data volume  
**Skipped / future run**: OpenAI and Plex API keys are passed as plain env vars in the compose file — consider using Docker secrets or a secret manager for production
