### PR TITLE
fix(db): pass ctx to AutoMigrate so gorm logger uses request logger

### DIFF
--- a/lib/db/migrations.go
+++ b/lib/db/migrations.go
@@ -49,7 +49,7 @@ func RunMigrations(ctx context.Context, db *gorm.DB) error {
 		return fmt.Errorf("failed to enable SQLite optimizations: %w", err)
 	}
 
-	if err := db.AutoMigrate(&models.Movie{}, &models.TVShow{}, &models.Recommendation{}); err != nil {
+	if err := db.WithContext(ctx).AutoMigrate(&models.Movie{}, &models.TVShow{}, &models.Recommendation{}); err != nil {
 		return fmt.Errorf("failed to migrate database: %w", err)
 	}
 


### PR DESCRIPTION
## Summary

`RunMigrations` called `db.AutoMigrate(...)` without `WithContext(ctx)`, so gorm's Trace callback ran with an empty context and `gutil/logging.FromContext` fell back to a fresh "unknown" logger — producing ~14 spurious `"could not sync logger"` debug lines on every startup.

Switched to `db.WithContext(ctx).AutoMigrate(...)` to match the other helpers in this file.

Made with [Cursor](https://cursor.com)