### PR TITLE
chore: Add OCI annotation labels for GHCR

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,9 @@ RUN CGO_ENABLED=1 GOOS=linux go build -o recommender
 # Use a minimal alpine image for the final stage
 FROM alpine:3.23
 
+LABEL org.opencontainers.image.source=https://github.com/icco/recommender
+LABEL org.opencontainers.image.description="ghcr.io/icco/recommender container image"
+
 WORKDIR /app
 
 # Only install runtime dependencies.

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ RUN CGO_ENABLED=1 GOOS=linux go build -o recommender
 FROM alpine:3.23
 
 LABEL org.opencontainers.image.source=https://github.com/icco/recommender
-LABEL org.opencontainers.image.description="ghcr.io/icco/recommender container image"
+LABEL org.opencontainers.image.description="Daily movie and TV recommendations from a Plex library, enriched with TMDb metadata and chosen by OpenAI; a Go service with SQLite storage."
 
 WORKDIR /app
 


### PR DESCRIPTION
Adds the GitHub-recommended OCI annotation labels to the Dockerfile so that
the GHCR package page links back to this repo and shows description/license.

See: https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry#labelling-container-images

Labels added to the final image stage:
- `org.opencontainers.image.source`
- `org.opencontainers.image.description`
- `org.opencontainers.image.licenses` (where a recognizable LICENSE exists)