### PR TITLE
fix: address golangci-lint findings

### DIFF
--- a/handlers/handlers.go
+++ b/handlers/handlers.go
@@ -1,3 +1,5 @@
+// Package handlers contains the HTTP handlers and shared rendering helpers
+// for the recommender web service.
 package handlers
 
 import (
@@ -263,6 +265,11 @@ const cronBackgroundLockKey = "cron-serial"
 // HandleCron handles the recommendation generation cron job.
 // It takes a recommender instance and file lock, and returns an HTTP handler.
 // The job runs asynchronously and generates recommendations for the current day.
+//
+//nolint:contextcheck // background cron job + deferred Unlock intentionally use a
+// fresh context.Background() rather than the request context, because the work
+// must outlive the inbound HTTP request and the lock must release even if the
+// background timeout fires.
 func HandleCron(r *recommend.Recommender, fl *lock.FileLock) http.HandlerFunc {
 	return func(w http.ResponseWriter, req *http.Request) {
 		ctx := req.Context()
@@ -326,8 +333,11 @@ func HandleCron(r *recommend.Recommender, fl *lock.FileLock) http.HandlerFunc {
 			return
 		}
 
-		// Background work needs its own context independent of the request, but with the
-		// same logger so cron logs remain correlated.
+		// Background work must outlive the inbound HTTP request, so we deliberately
+		// detach from req.Context() and start a fresh context that only carries the
+		// scoped logger. The request context would otherwise be canceled the moment
+		// we return the 200 response, killing the generation job mid-flight.
+		//nolint:contextcheck // intentional detach: background cron must outlive the request
 		genCtx, genCancel := context.WithTimeout(logging.NewContext(context.Background(), l), 5*time.Minute)
 		l.Infow("Dispatching recommendation generation to background",
 			"date", today,
@@ -336,6 +346,9 @@ func HandleCron(r *recommend.Recommender, fl *lock.FileLock) http.HandlerFunc {
 		go func() {
 			defer func() {
 				genCancel()
+				// Unlock must succeed even if the background context has timed out,
+				// so we use a fresh context.Background() rather than genCtx here.
+				//nolint:contextcheck // intentional detach: unlock must run even after genCtx timeout
 				if err := fl.Unlock(context.Background(), lockKey); err != nil {
 					l.Errorw("Failed to release lock after recommendation generation",
 						"lock_key", lockKey,
@@ -372,6 +385,11 @@ func HandleCron(r *recommend.Recommender, fl *lock.FileLock) http.HandlerFunc {
 // HandleCache handles the Plex cache update cron job.
 // It takes a Plex client instance and file lock, and returns an HTTP handler.
 // The job runs asynchronously and updates the cache of available media.
+//
+//nolint:contextcheck // background cache job + deferred Unlock intentionally use a
+// fresh context.Background() rather than the request context, because the work
+// must outlive the inbound HTTP request and the lock must release even if the
+// background timeout fires.
 func HandleCache(p *plex.Client, fl *lock.FileLock) http.HandlerFunc {
 	return func(w http.ResponseWriter, req *http.Request) {
 		ctx := req.Context()
@@ -404,6 +422,9 @@ func HandleCache(p *plex.Client, fl *lock.FileLock) http.HandlerFunc {
 			return
 		}
 
+		// See HandleCron above: background cache work must outlive the request, so
+		// the context is intentionally detached.
+		//nolint:contextcheck // intentional detach: background cache job must outlive the request
 		bgCtx, cancel := context.WithTimeout(logging.NewContext(context.Background(), l), 5*time.Minute)
 		l.Infow("Dispatching Plex cache update to background",
 			"lock_key", lockKey,
@@ -411,6 +432,7 @@ func HandleCache(p *plex.Client, fl *lock.FileLock) http.HandlerFunc {
 		go func() {
 			defer func() {
 				cancel()
+				//nolint:contextcheck // intentional detach: unlock must run even after bgCtx timeout
 				if err := fl.Unlock(context.Background(), lockKey); err != nil {
 					l.Errorw("Failed to release lock after cache update",
 						"lock_key", lockKey,

--- a/handlers/templates/embed.go
+++ b/handlers/templates/embed.go
@@ -1,6 +1,9 @@
+// Package templates embeds the HTML templates rendered by the handlers package.
 package templates
 
 import "embed"
 
+// FS holds the embedded HTML templates served by the handlers package.
+//
 //go:embed *.html
 var FS embed.FS

--- a/lib/db/logger.go
+++ b/lib/db/logger.go
@@ -1,3 +1,5 @@
+// Package db provides database setup, automatic migrations, and a custom
+// GORM logger that forwards SQL traces through zap-backed structured logging.
 package db
 
 import (
@@ -24,7 +26,7 @@ func NewGormLogger(base *zap.Logger) *GormLogger {
 
 // LogMode is part of gorm's logger.Interface; zap controls leveling so we
 // just return the receiver unchanged.
-func (l *GormLogger) LogMode(level logger.LogLevel) logger.Interface {
+func (l *GormLogger) LogMode(_ logger.LogLevel) logger.Interface {
 	return l
 }
 

--- a/lib/db/migrations.go
+++ b/lib/db/migrations.go
@@ -45,9 +45,7 @@ var (
 
 // RunMigrations runs all database migrations.
 func RunMigrations(ctx context.Context, db *gorm.DB) error {
-	if err := enableSQLiteOptimizations(ctx, db); err != nil {
-		return fmt.Errorf("failed to enable SQLite optimizations: %w", err)
-	}
+	enableSQLiteOptimizations(ctx, db)
 
 	if err := db.WithContext(ctx).AutoMigrate(&models.Movie{}, &models.TVShow{}, &models.Recommendation{}); err != nil {
 		return fmt.Errorf("failed to migrate database: %w", err)
@@ -68,9 +66,7 @@ func RunMigrations(ctx context.Context, db *gorm.DB) error {
 		return fmt.Errorf("failed to drop indexes: %w", err)
 	}
 
-	if err := createAdditionalIndexes(ctx, db); err != nil {
-		return fmt.Errorf("failed to create additional indexes: %w", err)
-	}
+	createAdditionalIndexes(ctx, db)
 
 	return nil
 }
@@ -116,7 +112,8 @@ func dropTableIfExists(ctx context.Context, db *gorm.DB, tableName string) error
 }
 
 // enableSQLiteOptimizations enables SQLite-specific optimizations.
-func enableSQLiteOptimizations(ctx context.Context, db *gorm.DB) error {
+// Pragma failures are logged but never aborts startup.
+func enableSQLiteOptimizations(ctx context.Context, db *gorm.DB) {
 	l := logging.FromContext(ctx)
 	optimizations := []string{
 		"PRAGMA journal_mode=WAL",    // Enable WAL mode for better concurrency
@@ -135,12 +132,11 @@ func enableSQLiteOptimizations(ctx context.Context, db *gorm.DB) error {
 			l.Infow("Successfully executed pragma", "pragma", pragma)
 		}
 	}
-
-	return nil
 }
 
 // createAdditionalIndexes creates additional indexes for performance.
-func createAdditionalIndexes(ctx context.Context, db *gorm.DB) error {
+// Failures to create an individual index are logged but never aborts startup.
+func createAdditionalIndexes(ctx context.Context, db *gorm.DB) {
 	l := logging.FromContext(ctx)
 	additionalIndexes := []string{
 		"CREATE INDEX IF NOT EXISTS idx_movies_title_year ON movies(title, year)",
@@ -161,6 +157,4 @@ func createAdditionalIndexes(ctx context.Context, db *gorm.DB) error {
 			l.Infow("Successfully created index", "sql", indexSQL)
 		}
 	}
-
-	return nil
 }

--- a/lib/health/health.go
+++ b/lib/health/health.go
@@ -1,3 +1,5 @@
+// Package health exposes a /health HTTP handler that reports liveness and
+// database connectivity for the recommender service.
 package health
 
 import (

--- a/lib/plex/client.go
+++ b/lib/plex/client.go
@@ -1,3 +1,5 @@
+// Package plex provides a thin client over plexgo for fetching library data
+// from a Plex Media Server and persisting it into the local GORM cache.
 package plex
 
 import (
@@ -187,8 +189,8 @@ func (c *Client) GetAllLibraries(ctx context.Context) ([]LibrarySectionInfo, err
 	return libs, nil
 }
 
-// PlexItem represents a media item from Plex
-type PlexItem struct {
+// Item represents a media item from Plex.
+type Item struct {
 	RatingKey  string
 	Key        string
 	Title      string
@@ -209,7 +211,7 @@ type PlexItem struct {
 
 // GetPlexItems lists a section via plexgo Content.ListContent (GET …/library/sections/{id}/all)
 // with container paging. When unwatchedOnly is true, watched items are dropped in memory.
-func (c *Client) GetPlexItems(ctx context.Context, libraryKey string, unwatchedOnly bool) ([]PlexItem, error) {
+func (c *Client) GetPlexItems(ctx context.Context, libraryKey string, unwatchedOnly bool) ([]Item, error) {
 	l := logging.FromContext(ctx)
 	l.Debugw("Getting library details from Plex API",
 		"section_key", libraryKey,
@@ -224,7 +226,7 @@ func (c *Client) GetPlexItems(ctx context.Context, libraryKey string, unwatchedO
 		"directory_count", len(rawItems),
 	)
 
-	var allItems []PlexItem
+	var allItems []Item
 	for _, item := range rawItems {
 		if unwatchedOnly && item.ViewCount != nil && *item.ViewCount > 0 {
 			continue
@@ -453,8 +455,8 @@ func (c *Client) UpdateCache(ctx context.Context) error {
 	}
 	l.Infow("Successfully fetched libraries", "count", len(libraries))
 
-	var allMovies []PlexItem
-	var allTVShows []PlexItem
+	var allMovies []Item
+	var allTVShows []Item
 	var fetchErrCount int
 
 	libs := libraries
@@ -565,7 +567,7 @@ var tvUpsertColumns = []string{
 }
 
 // upsertMovieBatch upserts movies by plex_rating_key in a single transaction.
-func (c *Client) upsertMovieBatch(ctx context.Context, movies []PlexItem) error {
+func (c *Client) upsertMovieBatch(ctx context.Context, movies []Item) error {
 	return c.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
 		now := time.Now()
 		for _, item := range movies {
@@ -625,7 +627,7 @@ func (c *Client) upsertMovieBatch(ctx context.Context, movies []PlexItem) error 
 }
 
 // upsertTVShowBatch upserts TV shows by plex_rating_key in a single transaction.
-func (c *Client) upsertTVShowBatch(ctx context.Context, shows []PlexItem) error {
+func (c *Client) upsertTVShowBatch(ctx context.Context, shows []Item) error {
 	return c.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
 		now := time.Now()
 		for _, item := range shows {

--- a/lib/plex/client_cache_test.go
+++ b/lib/plex/client_cache_test.go
@@ -31,7 +31,7 @@ func TestUpsertMovieBatch_updatesSameRow(t *testing.T) {
 	}
 	ctx := t.Context()
 
-	v1 := []PlexItem{{RatingKey: "501", Key: "/m/501", Title: "Alpha", Type: models.TypeMovie, AddedAt: 1}}
+	v1 := []Item{{RatingKey: "501", Key: "/m/501", Title: "Alpha", Type: models.TypeMovie, AddedAt: 1}}
 	if err := c.upsertMovieBatch(ctx, v1); err != nil {
 		t.Fatal(err)
 	}
@@ -40,7 +40,7 @@ func TestUpsertMovieBatch_updatesSameRow(t *testing.T) {
 		t.Fatalf("first insert id=%d err=%v", id1, err)
 	}
 
-	v2 := []PlexItem{{RatingKey: "501", Key: "/m/501", Title: "Beta", Type: models.TypeMovie, AddedAt: 2}}
+	v2 := []Item{{RatingKey: "501", Key: "/m/501", Title: "Beta", Type: models.TypeMovie, AddedAt: 2}}
 	if err := c.upsertMovieBatch(ctx, v2); err != nil {
 		t.Fatal(err)
 	}
@@ -71,7 +71,7 @@ func TestRemoveMoviesNotInSnapshot_clearsRecFK(t *testing.T) {
 	}
 	ctx := t.Context()
 
-	if err := c.upsertMovieBatch(ctx, []PlexItem{
+	if err := c.upsertMovieBatch(ctx, []Item{
 		{RatingKey: "10", Key: "/m/10", Title: "Keep", Type: models.TypeMovie, AddedAt: 1},
 		{RatingKey: "11", Key: "/m/11", Title: "Drop", Type: models.TypeMovie, AddedAt: 1},
 	}); err != nil {

--- a/lib/plex/client_test.go
+++ b/lib/plex/client_test.go
@@ -66,7 +66,7 @@ func TestGetAllLibraries_ignoresNumericBoolsOnSection(t *testing.T) {
 	t.Parallel()
 	// Newer PMS can send 0/1 for flags; plexgo's *bool models reject that — we skip those keys.
 	const payload = `{"MediaContainer":{"allowSync":1,"size":1,"Directory":[{"key":"2","title":"TV","type":"show","content":1,"directory":0,"filters":1,"hidden":0,"language":"en","uuid":"u2"}]}}`
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(payload))
 	}))
@@ -123,7 +123,7 @@ func TestGetPlexItems_toleratesNumericBoolsAndNumericRatingKey(t *testing.T) {
 	t.Parallel()
 	// Newer PMS can send 0/1 for Metadata fields modeled as *bool in plexgo.
 	const payload = `{"MediaContainer":{"totalSize":1,"Metadata":[{"ratingKey":99,"key":"/library/metadata/99","title":"Numeric Key","type":"movie","addedAt":1,"search":1,"secondary":0,"year":2021,"Genre":[{"tag":"Comedy"}]}]}}`
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(payload))
 	}))

--- a/lib/plex/plexgo_convert.go
+++ b/lib/plex/plexgo_convert.go
@@ -70,7 +70,7 @@ type sectionListMetadata struct {
 	ChildCount *int `json:"childCount,omitempty"`
 }
 
-func sectionMetadataToPlexItem(md sectionListMetadata) PlexItem {
+func sectionMetadataToPlexItem(md sectionListMetadata) Item {
 	var genres []components.Tag
 	for _, g := range md.Genre {
 		genres = append(genres, components.Tag{Tag: g.Tag})
@@ -85,7 +85,7 @@ func sectionMetadataToPlexItem(md sectionListMetadata) PlexItem {
 	if md.Summary != nil {
 		summary = *md.Summary
 	}
-	return PlexItem{
+	return Item{
 		RatingKey:  rk,
 		Key:        md.Key,
 		Title:      md.Title,
@@ -107,11 +107,11 @@ func sectionMetadataToPlexItem(md sectionListMetadata) PlexItem {
 
 // listSectionContentAll pages GET /library/sections/{id}/all with a tolerant JSON decode.
 // It does not use plexgo's full Metadata type (PMS can send numeric booleans on movie rows).
-func (c *Client) listSectionContentAll(ctx context.Context, sectionID string) ([]PlexItem, error) {
+func (c *Client) listSectionContentAll(ctx context.Context, sectionID string) ([]Item, error) {
 	l := logging.FromContext(ctx)
 	const pageSize = 200
 	start := 0
-	var all []PlexItem
+	var all []Item
 	base := strings.TrimRight(c.plexURL, "/")
 
 	for range 500 {

--- a/lib/recommend/prompts/embed.go
+++ b/lib/recommend/prompts/embed.go
@@ -1,6 +1,10 @@
+// Package prompts embeds the OpenAI prompt templates used by the recommend
+// package for generating movie and TV show recommendations.
 package prompts
 
 import "embed"
 
+// FS holds the embedded OpenAI prompt templates used by the recommend package.
+//
 //go:embed *.txt
 var FS embed.FS

--- a/lib/recommend/recommend.go
+++ b/lib/recommend/recommend.go
@@ -1,3 +1,6 @@
+// Package recommend orchestrates daily movie and TV-show recommendation
+// generation, combining cached Plex library data with OpenAI-powered
+// prompting and result validation.
 package recommend
 
 import (
@@ -527,7 +530,7 @@ func (r *Recommender) GenerateRecommendations(ctx context.Context, date time.Tim
 	seenTitles := make(map[string]bool)
 
 	// Helper function to process recommendation items
-	processItems := func(items []RecommendationItem, contentType string) {
+	processItems := func(items []RecommendationItem, _ string) {
 		for _, item := range items {
 			if seenTitles[item.Title] {
 				continue
@@ -575,21 +578,21 @@ func (r *Recommender) GenerateRecommendations(ctx context.Context, date time.Tim
 	for _, rec := range recommendations {
 		if rec.Type == models.TypeMovie && typeCounts[models.TypeMovie] < targetMovieCount {
 			// Try to get diverse genres, but be flexible if content is limited
-			if strings.Contains(strings.ToLower(rec.Genre), "comedy") && !movieTypes["funny"] {
+			genre := strings.ToLower(rec.Genre)
+			switch {
+			case strings.Contains(genre, "comedy") && !movieTypes["funny"]:
 				filteredRecommendations = append(filteredRecommendations, rec)
 				typeCounts[models.TypeMovie]++
 				movieTypes["funny"] = true
-			} else if (strings.Contains(strings.ToLower(rec.Genre), "action") ||
-				strings.Contains(strings.ToLower(rec.Genre), "drama")) &&
-				!movieTypes["action_drama"] {
+			case (strings.Contains(genre, "action") || strings.Contains(genre, "drama")) && !movieTypes["action_drama"]:
 				filteredRecommendations = append(filteredRecommendations, rec)
 				typeCounts[models.TypeMovie]++
 				movieTypes["action_drama"] = true
-			} else if !movieTypes["rewatched"] {
+			case !movieTypes["rewatched"]:
 				filteredRecommendations = append(filteredRecommendations, rec)
 				typeCounts[models.TypeMovie]++
 				movieTypes["rewatched"] = true
-			} else if typeCounts[models.TypeMovie] < targetMovieCount { // Add additional movies up to target
+			case typeCounts[models.TypeMovie] < targetMovieCount: // Add additional movies up to target
 				filteredRecommendations = append(filteredRecommendations, rec)
 				typeCounts[models.TypeMovie]++
 			}

--- a/lib/sanitize/sanitize.go
+++ b/lib/sanitize/sanitize.go
@@ -1,3 +1,6 @@
+// Package sanitize provides helpers for scrubbing user-controlled values
+// before they are written to structured logs, plus thin wrappers that emit
+// recommendation/cache cron-job lifecycle log lines with consistent fields.
 package sanitize
 
 import "strings"

--- a/lib/tmdb/client.go
+++ b/lib/tmdb/client.go
@@ -1,3 +1,6 @@
+// Package tmdb provides a small client for The Movie Database REST API,
+// including rate limiting, retry, and circuit-breaker behavior used by the
+// recommender service.
 package tmdb
 
 import (
@@ -286,7 +289,7 @@ func (c *Client) SearchMovie(ctx context.Context, title string, year int) (*Sear
 		return &result, nil
 	}
 
-	for attempt := 0; attempt < 3; attempt++ {
+	for attempt := range 3 {
 		result, err := retryFunc()
 		if err == nil {
 			return result, nil
@@ -380,7 +383,7 @@ func (c *Client) SearchTVShow(ctx context.Context, title string, year int) (*TVS
 		return &result, nil
 	}
 
-	for attempt := 0; attempt < 3; attempt++ {
+	for attempt := range 3 {
 		result, err := retryFunc()
 		if err == nil {
 			return result, nil

--- a/lib/validation/schema.go
+++ b/lib/validation/schema.go
@@ -1,3 +1,6 @@
+// Package validation provides JSON schema validation helpers used to
+// sanitize external API responses (e.g. OpenAI) and basic input validation
+// (date / pagination parameters) for the recommender service.
 package validation
 
 import (

--- a/models/models.go
+++ b/models/models.go
@@ -1,3 +1,6 @@
+// Package models defines the GORM-mapped types persisted to the SQLite
+// database (movies, TV shows, recommendations) plus the small set of shared
+// type-name constants used to discriminate rows.
 package models
 
 import (

--- a/static/embed.go
+++ b/static/embed.go
@@ -1,3 +1,5 @@
+// Package static provides the embedded static assets (favicon, etc.) that
+// the recommender service serves under /static/.
 package static
 
 import "embed"


### PR DESCRIPTION
## Summary
The new `golangci-lint` workflow added a stricter linter set (`bodyclose,misspell,gosec,errorlint,noctx,contextcheck,nilerr,wastedassign,unparam,copyloopvar,intrange,revive,gocritic,unconvert`). This PR fixes all 19 findings so the lint check passes, plus the additional revive package-comment findings that surfaced once the noisier ones were resolved.

## Changes
- **revive (package-comments)**: Added `// Package <name>` doc comments to `handlers`, `lib/db`, `lib/health`, `lib/plex`, `lib/recommend`, `lib/sanitize`, `lib/tmdb`, `lib/validation`, `models`, and `static`.
- **revive (exported)**: Added doc comments to the exported `FS` vars in `handlers/templates/embed.go` and `lib/recommend/prompts/embed.go`.
- **revive (exported - stuttering name)**: Renamed `plex.PlexItem` to `plex.Item` and updated all in-package references. The struct is only used inside `lib/plex` (verified via grep) so this is not an external API break.
- **revive (unused-parameter)**: Renamed unused parameters to `_` in `GormLogger.LogMode`, the `processItems` closure in `recommend.go`, and two `httptest.NewServer` handler closures in `lib/plex/client_test.go`.
- **gocritic (ifElseChain)**: Converted the genre-classification `if / else if` chain in `recommend.go` to a `switch` statement.
- **unparam**: `enableSQLiteOptimizations` and `createAdditionalIndexes` always returned `nil`, so the unused `error` return was dropped and the callers in `RunMigrations` simplified.
- **contextcheck**: The two background cron handlers (`HandleCron`, `HandleCache`) deliberately detach from the request context with `context.Background()` because the work must outlive the HTTP request and the deferred `Unlock` must run even after the background timeout fires. Annotated with `//nolint:contextcheck` plus an explanatory comment at the function level.
- **intrange (auto-fix)**: `lib/tmdb/client.go` retry loops switched from `for attempt := 0; attempt < 3; attempt++` to `for attempt := range 3`.

## Verification
- `golangci-lint run -E bodyclose,misspell,gosec,errorlint,noctx,contextcheck,nilerr,wastedassign,unparam,copyloopvar,intrange,revive,gocritic,unconvert ./...` — `0 issues.`
- `go build ./...` — passes
- `go test ./...` — passes (existing tests in `lib/plex` and `lib/recommend`)

[Generated with Claude Code](https://claude.com/claude-code)