### PR TITLE
feat: add Trakt and AniList signal sources

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,8 +66,13 @@ docker compose down
 - `GOOGLE_GENAI_USE_VERTEXAI`: `true` to use Vertex AI (recommended)
 - `GEMINI_MODEL`: model ID (defaults to `gemini-2.5-flash`)
 - `GOOGLE_APPLICATION_CREDENTIALS`: service-account key path for local dev (prod uses ambient ADC)
+- `TRAKT_CLIENT_ID` / `TRAKT_CLIENT_SECRET`: enable Trakt signals
+- `TRAKT_CONNECT_TOKEN`: shared secret required to call `GET /trakt/connect` (disabled when unset)
+- `ANILIST_USERNAME`: enable AniList (public list) signals
 - `PORT`: HTTP server port (defaults to 8080)
 - `DB_PATH`: Database file path (defaults to recommender.db)
+
+External signals (Trakt watched/ratings/watchlist, AniList scores) are synced during `/cron/cache` into `ExternalSignal` and only re-rank owned Plex titles: they feed genre affinity, a watchlist score boost, watched-elsewhere handling, and prompt context. Sources are optional and skipped when their env vars are unset. Trakt OAuth (device flow) tokens live in `OAuthToken`; authorize via `GET /trakt/connect?token=…`.
 
 Auth to Vertex AI uses Application Default Credentials — no API key.
 
@@ -572,6 +577,7 @@ All file operations use restrictive permissions (0600 for files, 0750 for direct
 - `PLEX_TOKEN`: Plex authentication token
 - `TMDB_API_KEY`: The Movie Database API key
 - `GOOGLE_CLOUD_PROJECT` / `GOOGLE_CLOUD_LOCATION`: Vertex AI project + region (auth via ADC)
+- Optional signals: `TRAKT_CLIENT_ID`/`TRAKT_CLIENT_SECRET`/`TRAKT_CONNECT_TOKEN`, `ANILIST_USERNAME`
 - `PORT`: HTTP server port (defaults to 8080)
 
 **Startup Sequence:**

--- a/README.md
+++ b/README.md
@@ -52,10 +52,23 @@ Past days are listed at `/dates` (one row per distinct day, paginated).
 | `GOOGLE_GENAI_USE_VERTEXAI` | no | `true` to use Vertex AI (recommended); the SDK also supports the Gemini Developer API |
 | `GEMINI_MODEL` | no | Model ID (default `gemini-2.5-flash`) |
 | `GOOGLE_APPLICATION_CREDENTIALS` | no | Path to a service-account key for local dev; production uses ambient ADC (workload identity) |
+| `TRAKT_CLIENT_ID` | no | Trakt API app client id; enables Trakt signals |
+| `TRAKT_CLIENT_SECRET` | no | Trakt API app client secret |
+| `TRAKT_CONNECT_TOKEN` | no | Shared secret required to call `GET /trakt/connect?token=…`; the endpoint is disabled when unset |
+| `ANILIST_USERNAME` | no | AniList username (public list); enables AniList signals |
 | `PORT` | no | HTTP port (default `8080`) |
 | `DB_PATH` | no | SQLite file path (default `recommender.db`; Docker Compose uses `/data/recommender.db`) |
 
 Authentication to Vertex AI uses [Application Default Credentials](https://cloud.google.com/docs/authentication/application-default-credentials) — no API key. Locally, run `gcloud auth application-default login` or set `GOOGLE_APPLICATION_CREDENTIALS`.
+
+### Signal sources (optional)
+
+External sources only **re-rank titles you already own in Plex** — they never add new titles. Both are off unless configured, and are synced during `/cron/cache`.
+
+- **Trakt** (watched / ratings / watchlist): register a Trakt API app, set `TRAKT_CLIENT_ID`/`TRAKT_CLIENT_SECRET` and a `TRAKT_CONNECT_TOKEN`, then authorize once — `curl "http://localhost:8080/trakt/connect?token=$TRAKT_CONNECT_TOKEN"` and enter the returned code at the Trakt URL. Tokens persist in the DB and auto-refresh.
+- **AniList** (anime scores): set `ANILIST_USERNAME` (public list; no auth). Matched to owned anime by title + year.
+
+Signals feed genre affinity, a watchlist score boost, watched-elsewhere handling, and a short "recently loved" line in the prompt.
 
 ## Repository layout
 

--- a/docs/superpowers/plans/2026-07-06-signal-sources.md
+++ b/docs/superpowers/plans/2026-07-06-signal-sources.md
@@ -1,0 +1,1760 @@
+# Signal Sources (Trakt + AniList) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Feed Trakt (watched/ratings/watchlist) and AniList (anime scores) into recommendations as ranking signals over Plex-owned titles, in a single PR.
+
+**Architecture:** Two API clients (`lib/trakt`, `lib/anilist`) with overridable base URLs for httptest. A `SignalSource` interface + adapters in `lib/recommend/signals.go` join fetched data to Plex rows by ID (Trakt) or title+year (AniList) and upsert `ExternalSignal`. `/cron/cache` runs `SyncSignals` after the Plex upsert. Consumption extends `genreAffinity`, `loadCandidates`/`scoreCandidate`, and the prompt. Both sources are optional (env-gated).
+
+**Tech Stack:** Go 1.26, GORM + SQLite, Gemini/Vertex, `net/http` + `net/http/httptest`.
+
+## Global Constraints
+
+- Module `github.com/icco/recommender`, `go 1.26.2`.
+- **Signals only rank Plex-owned titles; store a signal only when it joins to an owned title.** Unmatched → dropped, not an error.
+- Both sources **optional**: `TRAKT_CLIENT_ID`+`TRAKT_CLIENT_SECRET` unset → Trakt skipped; `ANILIST_USERNAME` unset → AniList skipped.
+- Join order for Trakt: TMDb → IMDb → TVDb. AniList: title (romaji/english) + year.
+- Signal kinds (exist in `models`): `SignalKindWatched`, `SignalKindRated`, `SignalKindScore`, `SignalKindWatchlist`. Sources: `SourcePlex` (exists); add `SourceTrakt`, `SourceAniList`.
+- Per-source sync failures are logged and never fail the cache job or other sources.
+- `ExternalSignal` unique index is `(source, external_ref, kind)` — upsert on conflict.
+- Loggers from `logging.FromContext(ctx)`; no `log/slog`.
+- Branch `signal-sources-trakt-anilist`. Never commit to main; never force-push.
+- Every task ends green: `go build ./... && go test ./... && gofmt -l . && go vet ./...`.
+- golangci-lint (CI enables `bodyclose,misspell,gosec,errorlint,noctx,contextcheck,nilerr,wastedassign,unparam,copyloopvar,intrange,revive,gocritic,unconvert`) must pass: wrap errors with `%w`; give HTTP requests a ctx (`http.NewRequestWithContext`); `defer resp.Body.Close()`; exported struct fields use Go initialisms (`ID`, `URL`, `IMDb`/`TMDb` acceptable as-is since they're not initialisms revive flags — but `Url`→`URL`).
+- Commit trailer: `Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>`. No "Generated with Claude Code" footer.
+
+## File Structure
+
+**New:**
+- `lib/trakt/client.go`, `lib/trakt/client_test.go` — Trakt API client (device flow, refresh, sync).
+- `lib/anilist/client.go`, `lib/anilist/client_test.go` — AniList GraphQL client.
+- `lib/recommend/signals.go`, `lib/recommend/signals_test.go` — `SignalSource`, Trakt/AniList adapters, `SyncSignals`, Trakt connect.
+
+**Modified:**
+- `models/models.go` — `SourceTrakt`/`SourceAniList` consts, `OAuthToken` model.
+- `lib/db/migrations.go` — AutoMigrate `OAuthToken`.
+- `lib/recommend/recommend.go` — `New` gains `SignalConfig`; struct fields.
+- `lib/recommend/recommend_test.go` — `testDB` migrates `OAuthToken`.
+- `lib/recommend/profile.go` — `genreAffinity` blends signals; `lovedTitles`.
+- `lib/recommend/candidates.go` — watchlist boost + external-watched; `candidate.Watchlisted`; `scoreCandidate`.
+- `lib/recommend/generate.go` — prompt `Loved` context.
+- `lib/recommend/prompts/recommendation.txt` — render `Loved`.
+- `handlers/handlers.go` — `HandleCache` runs `SyncSignals`; new `HandleTraktConnect`.
+- `main.go` — read env, build `SignalConfig`, register `/trakt/connect`, pass recommender to `HandleCache`.
+- `README.md`, `template.env`, `CLAUDE.md` — new env vars + endpoints.
+
+---
+
+## Task 1: OAuthToken model + source constants
+
+**Files:** Modify `models/models.go`, `lib/db/migrations.go`, `lib/recommend/recommend_test.go`; Test `lib/db/migrations_test.go`.
+
+**Interfaces:**
+- Produces: `models.SourceTrakt = "trakt"`, `models.SourceAniList = "anilist"`; `models.OAuthToken{ID uint; Source string; AccessToken string; RefreshToken string; ExpiresAt time.Time; UpdatedAt time.Time}`.
+
+- [ ] **Step 1: Add constants and model**
+
+In `models/models.go`, add to the signal-source const block:
+
+```go
+	SourceTrakt   = "trakt"
+	SourceAniList = "anilist"
+```
+
+Append the model:
+
+```go
+// OAuthToken stores an OAuth token set for an external source (e.g. Trakt).
+type OAuthToken struct {
+	ID           uint   `gorm:"primarykey"`
+	Source       string `gorm:"type:varchar(32);not null;uniqueIndex:idx_oauth_source"`
+	AccessToken  string `gorm:"type:varchar(512)"`
+	RefreshToken string `gorm:"type:varchar(512)"`
+	ExpiresAt    time.Time
+	UpdatedAt    time.Time
+}
+```
+
+- [ ] **Step 2: Register in migrations and test DB**
+
+In `lib/db/migrations.go`, add `&models.OAuthToken{}` to the `AutoMigrate(...)` call. In `lib/recommend/recommend_test.go` `testDB`, add `&models.OAuthToken{}` to its `AutoMigrate(...)`.
+
+- [ ] **Step 3: Extend the migration test**
+
+In `lib/db/migrations_test.go`, add to `TestRunMigrations_createsNewTables` before the final assertions:
+
+```go
+	if !gdb.Migrator().HasTable(&models.OAuthToken{}) {
+		t.Fatal("oauth_tokens table missing")
+	}
+```
+
+- [ ] **Step 4: Run**
+
+Run: `go test ./lib/db/... -run TestRunMigrations_createsNewTables -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add models/models.go lib/db/migrations.go lib/db/migrations_test.go lib/recommend/recommend_test.go
+git commit -m "feat: add OAuthToken model and Trakt/AniList source constants
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: Trakt API client
+
+**Files:** Create `lib/trakt/client.go`, `lib/trakt/client_test.go`.
+
+**Interfaces:**
+- Produces:
+  - `trakt.NewClient(clientID, clientSecret string) *Client` (field `BaseURL string` overridable in tests).
+  - `type IDs struct { Trakt int; IMDb string; TMDb int; TVDb int }` (json `trakt`/`imdb`/`tmdb`/`tvdb`).
+  - `type Media struct { Title string; Year int; IDs IDs }`.
+  - `type SyncRow struct { Rating int; Movie *Media; Show *Media }`.
+  - `type DeviceCode struct { DeviceCode, UserCode, VerificationURL string; ExpiresIn, Interval int }`.
+  - `type Token struct { AccessToken, RefreshToken string; ExpiresIn int; CreatedAt int64 }` with `func (Token) ExpiresAt() time.Time`.
+  - `func (c *Client) RequestDeviceCode(ctx) (*DeviceCode, error)`
+  - `func (c *Client) PollForToken(ctx, deviceCode string) (*Token, error)`
+  - `func (c *Client) RefreshToken(ctx, refreshToken string) (*Token, error)`
+  - `func (c *Client) Sync(ctx, accessToken, path string) ([]SyncRow, error)`
+
+- [ ] **Step 1: Write the client test**
+
+Create `lib/trakt/client_test.go`:
+
+```go
+package trakt
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestSync_parsesMoviesWithIDs(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("trakt-api-key") != "cid" || r.Header.Get("Authorization") != "Bearer tok" {
+			t.Errorf("missing auth headers: %v", r.Header)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`[{"rating":9,"movie":{"title":"The Matrix","year":1999,"ids":{"trakt":1,"imdb":"tt0133093","tmdb":603}}}]`))
+	}))
+	defer srv.Close()
+
+	c := NewClient("cid", "secret")
+	c.BaseURL = srv.URL
+	rows, err := c.Sync(context.Background(), "tok", "sync/ratings/movies")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(rows) != 1 || rows[0].Movie == nil || rows[0].Movie.IDs.TMDb != 603 || rows[0].Rating != 9 {
+		t.Fatalf("bad parse: %+v", rows)
+	}
+}
+
+func TestRequestDeviceCode(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"device_code":"dc","user_code":"1234","verification_url":"https://trakt.tv/activate","expires_in":600,"interval":5}`))
+	}))
+	defer srv.Close()
+	c := NewClient("cid", "secret")
+	c.BaseURL = srv.URL
+	dc, err := c.RequestDeviceCode(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if dc.UserCode != "1234" || dc.DeviceCode != "dc" {
+		t.Fatalf("bad device code: %+v", dc)
+	}
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `go test ./lib/trakt/... -v`
+Expected: FAIL (package does not compile — `NewClient` undefined).
+
+- [ ] **Step 3: Implement the client**
+
+Create `lib/trakt/client.go`:
+
+```go
+// Package trakt is a minimal Trakt API client: OAuth device flow, token
+// refresh, and the sync endpoints the recommender uses as ranking signals.
+package trakt
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+)
+
+const (
+	defaultBaseURL = "https://api.trakt.tv"
+	apiVersion     = "2"
+)
+
+// Client talks to the Trakt API. BaseURL is overridable for tests.
+type Client struct {
+	clientID     string
+	clientSecret string
+	BaseURL      string
+	httpClient   *http.Client
+}
+
+// NewClient returns a Trakt client for the given API app credentials.
+func NewClient(clientID, clientSecret string) *Client {
+	return &Client{
+		clientID:     clientID,
+		clientSecret: clientSecret,
+		BaseURL:      defaultBaseURL,
+		httpClient:   &http.Client{Timeout: 30 * time.Second},
+	}
+}
+
+// IDs holds the external identifiers Trakt returns for a title.
+type IDs struct {
+	Trakt int    `json:"trakt"`
+	IMDb  string `json:"imdb"`
+	TMDb  int    `json:"tmdb"`
+	TVDb  int    `json:"tvdb"`
+}
+
+// Media is a movie or show entry within a sync row.
+type Media struct {
+	Title string `json:"title"`
+	Year  int    `json:"year"`
+	IDs   IDs    `json:"ids"`
+}
+
+// SyncRow is one item from a sync/* endpoint. Exactly one of Movie/Show is set;
+// Rating is populated for ratings endpoints.
+type SyncRow struct {
+	Rating int    `json:"rating"`
+	Movie  *Media `json:"movie"`
+	Show   *Media `json:"show"`
+}
+
+// DeviceCode is the response from the device-code endpoint.
+type DeviceCode struct {
+	DeviceCode      string `json:"device_code"`
+	UserCode        string `json:"user_code"`
+	VerificationURL string `json:"verification_url"`
+	ExpiresIn       int    `json:"expires_in"`
+	Interval        int    `json:"interval"`
+}
+
+// Token is an OAuth token set.
+type Token struct {
+	AccessToken  string `json:"access_token"`
+	RefreshToken string `json:"refresh_token"`
+	ExpiresIn    int    `json:"expires_in"`
+	CreatedAt    int64  `json:"created_at"`
+}
+
+// ExpiresAt is when the access token expires.
+func (t Token) ExpiresAt() time.Time {
+	return time.Unix(t.CreatedAt, 0).Add(time.Duration(t.ExpiresIn) * time.Second)
+}
+
+func (c *Client) postJSON(ctx context.Context, path string, body, out any) (int, error) {
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return 0, fmt.Errorf("marshal body: %w", err)
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.BaseURL+"/"+path, bytes.NewReader(buf))
+	if err != nil {
+		return 0, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return 0, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	data, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return resp.StatusCode, err
+	}
+	if resp.StatusCode >= 400 {
+		return resp.StatusCode, fmt.Errorf("trakt %s: HTTP %d: %s", path, resp.StatusCode, string(data))
+	}
+	if out != nil {
+		if err := json.Unmarshal(data, out); err != nil {
+			return resp.StatusCode, fmt.Errorf("decode %s: %w", path, err)
+		}
+	}
+	return resp.StatusCode, nil
+}
+
+// RequestDeviceCode starts the OAuth device flow.
+func (c *Client) RequestDeviceCode(ctx context.Context) (*DeviceCode, error) {
+	var dc DeviceCode
+	if _, err := c.postJSON(ctx, "oauth/device/code", map[string]string{"client_id": c.clientID}, &dc); err != nil {
+		return nil, err
+	}
+	return &dc, nil
+}
+
+// PollForToken polls once for the token; HTTP 400 means "authorization pending".
+// Returns (nil, nil) when still pending so the caller can wait and retry.
+func (c *Client) PollForToken(ctx context.Context, deviceCode string) (*Token, error) {
+	var tok Token
+	status, err := c.postJSON(ctx, "oauth/device/token", map[string]string{
+		"code": deviceCode, "client_id": c.clientID, "client_secret": c.clientSecret,
+	}, &tok)
+	if status == http.StatusBadRequest {
+		return nil, nil // pending
+	}
+	if err != nil {
+		return nil, err
+	}
+	return &tok, nil
+}
+
+// RefreshToken exchanges a refresh token for a new token set.
+func (c *Client) RefreshToken(ctx context.Context, refreshToken string) (*Token, error) {
+	var tok Token
+	if _, err := c.postJSON(ctx, "oauth/token", map[string]string{
+		"refresh_token": refreshToken,
+		"client_id":     c.clientID,
+		"client_secret": c.clientSecret,
+		"grant_type":    "refresh_token",
+	}, &tok); err != nil {
+		return nil, err
+	}
+	return &tok, nil
+}
+
+// Sync GETs a sync/* endpoint (e.g. "sync/watched/movies") with the access token.
+func (c *Client) Sync(ctx context.Context, accessToken, path string) ([]SyncRow, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.BaseURL+"/"+path, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("trakt-api-version", apiVersion)
+	req.Header.Set("trakt-api-key", c.clientID)
+	req.Header.Set("Authorization", "Bearer "+accessToken)
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	data, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode >= 400 {
+		return nil, fmt.Errorf("trakt %s: HTTP %d: %s", path, resp.StatusCode, string(data))
+	}
+	var rows []SyncRow
+	if err := json.Unmarshal(data, &rows); err != nil {
+		return nil, fmt.Errorf("decode %s: %w", path, err)
+	}
+	return rows, nil
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `go test ./lib/trakt/... -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/trakt/
+git commit -m "feat(trakt): API client with device flow and sync endpoints
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: AniList API client
+
+**Files:** Create `lib/anilist/client.go`, `lib/anilist/client_test.go`.
+
+**Interfaces:**
+- Produces:
+  - `anilist.NewClient() *Client` (field `URL string` overridable).
+  - `type Entry struct { Title string; Year int; Score float64 }` (Score normalized 0..10).
+  - `func (c *Client) List(ctx, username string) ([]Entry, error)` — returns rated entries (score > 0), english title preferred then romaji.
+
+- [ ] **Step 1: Write the client test**
+
+Create `lib/anilist/client_test.go`:
+
+```go
+package anilist
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestList_normalizesScoresAndPicksTitle(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":{"User":{"mediaListOptions":{"scoreFormat":"POINT_100"}},
+			"MediaListCollection":{"lists":[{"entries":[
+				{"score":90,"media":{"seasonYear":2019,"title":{"romaji":"Kimetsu","english":"Demon Slayer"}}},
+				{"score":0,"media":{"seasonYear":2020,"title":{"romaji":"Unrated","english":null}}}
+			]}]}}}}`))
+	}))
+	defer srv.Close()
+
+	c := NewClient()
+	c.URL = srv.URL
+	entries, err := c.List(context.Background(), "nat")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 rated entry, got %d (%+v)", len(entries), entries)
+	}
+	if entries[0].Title != "Demon Slayer" || entries[0].Year != 2019 {
+		t.Errorf("bad title/year: %+v", entries[0])
+	}
+	if entries[0].Score < 8.9 || entries[0].Score > 9.1 {
+		t.Errorf("POINT_100 90 should normalize to ~9.0, got %.2f", entries[0].Score)
+	}
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `go test ./lib/anilist/... -v`
+Expected: FAIL (compile error, `NewClient` undefined).
+
+- [ ] **Step 3: Implement the client**
+
+Create `lib/anilist/client.go`:
+
+```go
+// Package anilist is a minimal AniList GraphQL client for a user's public anime
+// list and scores, used as a recommendation ranking signal.
+package anilist
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+)
+
+const defaultURL = "https://graphql.anilist.co"
+
+// Client queries the public AniList GraphQL API. URL is overridable for tests.
+type Client struct {
+	URL        string
+	httpClient *http.Client
+}
+
+// NewClient returns an AniList client.
+func NewClient() *Client {
+	return &Client{URL: defaultURL, httpClient: &http.Client{Timeout: 30 * time.Second}}
+}
+
+// Entry is one rated anime from a user's list, score normalized to 0..10.
+type Entry struct {
+	Title string
+	Year  int
+	Score float64
+}
+
+const listQuery = `query($u:String){
+  User(name:$u){ mediaListOptions { scoreFormat } }
+  MediaListCollection(userName:$u, type:ANIME){ lists { entries {
+    score
+    media { seasonYear title { romaji english } }
+  } } }
+}`
+
+// List returns the user's rated anime (score > 0) with scores normalized to 0..10.
+func (c *Client) List(ctx context.Context, username string) ([]Entry, error) {
+	reqBody, err := json.Marshal(map[string]any{
+		"query":     listQuery,
+		"variables": map[string]string{"u": username},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("marshal query: %w", err)
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.URL, bytes.NewReader(reqBody))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	data, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode >= 400 {
+		return nil, fmt.Errorf("anilist: HTTP %d: %s", resp.StatusCode, string(data))
+	}
+
+	var out struct {
+		Data struct {
+			User struct {
+				MediaListOptions struct {
+					ScoreFormat string `json:"scoreFormat"`
+				} `json:"mediaListOptions"`
+			} `json:"User"`
+			MediaListCollection struct {
+				Lists []struct {
+					Entries []struct {
+						Score float64 `json:"score"`
+						Media struct {
+							SeasonYear int `json:"seasonYear"`
+							Title      struct {
+								Romaji  string `json:"romaji"`
+								English string `json:"english"`
+							} `json:"title"`
+						} `json:"media"`
+					} `json:"entries"`
+				} `json:"lists"`
+			} `json:"MediaListCollection"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(data, &out); err != nil {
+		return nil, fmt.Errorf("decode anilist: %w", err)
+	}
+
+	format := out.Data.User.MediaListOptions.ScoreFormat
+	var entries []Entry
+	for _, l := range out.Data.MediaListCollection.Lists {
+		for _, e := range l.Entries {
+			if e.Score <= 0 {
+				continue
+			}
+			title := e.Media.Title.English
+			if title == "" {
+				title = e.Media.Title.Romaji
+			}
+			if title == "" {
+				continue
+			}
+			entries = append(entries, Entry{
+				Title: title,
+				Year:  e.Media.SeasonYear,
+				Score: normalizeScore(e.Score, format),
+			})
+		}
+	}
+	return entries, nil
+}
+
+// normalizeScore maps AniList's per-user score format to a 0..10 scale.
+func normalizeScore(score float64, format string) float64 {
+	switch format {
+	case "POINT_100":
+		return score / 10.0
+	case "POINT_5":
+		return score * 2.0
+	case "POINT_3":
+		return score / 3.0 * 10.0
+	default: // POINT_10, POINT_10_DECIMAL
+		return score
+	}
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `go test ./lib/anilist/... -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/anilist/
+git commit -m "feat(anilist): GraphQL client for a user's anime scores
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: SignalSource interface + Trakt adapter
+
+**Files:** Create `lib/recommend/signals.go`, `lib/recommend/signals_test.go`.
+
+**Interfaces:**
+- Consumes: `trakt.Client`, `models.OAuthToken`, `models.ExternalSignal`, `models.Movie/TVShow`.
+- Produces:
+  - `type SignalSource interface { Name() string; Sync(ctx context.Context) (int, error) }`
+  - `type traktSource struct { db *gorm.DB; client *trakt.Client }`
+  - `func (s *traktSource) Name() string` → `models.SourceTrakt`
+  - `func (s *traktSource) Sync(ctx) (int, error)`
+  - `func upsertSignal(ctx, db, sig models.ExternalSignal) error`
+  - `func matchPlexID(ctx, db, tmdb *int, imdb, tvdb string) (movieID, tvID *uint)`
+
+- [ ] **Step 1: Write the adapter test**
+
+Create `lib/recommend/signals_test.go`:
+
+```go
+package recommend
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/icco/recommender/lib/trakt"
+	"github.com/icco/recommender/models"
+)
+
+func TestTraktSource_Sync_joinsAndUpserts(t *testing.T) {
+	db := testDB(t)
+	ctx := context.Background()
+
+	tmdb603 := 603
+	if err := db.Create(&models.Movie{Title: "The Matrix", Year: 1999, TMDbID: &tmdb603, PlexRatingKey: "m1"}).Error; err != nil {
+		t.Fatal(err)
+	}
+	// Seed a valid, non-expired token so Sync skips refresh.
+	if err := db.Create(&models.OAuthToken{Source: models.SourceTrakt, AccessToken: "tok", RefreshToken: "r", ExpiresAt: time.Now().Add(time.Hour)}).Error; err != nil {
+		t.Fatal(err)
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/sync/ratings/movies":
+			_, _ = w.Write([]byte(`[{"rating":10,"movie":{"ids":{"tmdb":603}}},{"rating":8,"movie":{"ids":{"tmdb":999999}}}]`))
+		default:
+			_, _ = w.Write([]byte(`[]`))
+		}
+	}))
+	defer srv.Close()
+
+	c := trakt.NewClient("cid", "secret")
+	c.BaseURL = srv.URL
+	s := &traktSource{db: db, client: c}
+
+	n, err := s.Sync(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n == 0 {
+		t.Fatal("expected some signals synced")
+	}
+	var sigs []models.ExternalSignal
+	if err := db.Where("source = ? AND kind = ?", models.SourceTrakt, models.SignalKindRated).Find(&sigs).Error; err != nil {
+		t.Fatal(err)
+	}
+	// Only the tmdb=603 movie is owned; the 999999 one is dropped.
+	if len(sigs) != 1 || sigs[0].MovieID == nil || sigs[0].Value != 10 {
+		t.Fatalf("bad signals: %+v", sigs)
+	}
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `go test ./lib/recommend/... -run TestTraktSource_Sync -v`
+Expected: FAIL (undefined `traktSource`).
+
+- [ ] **Step 3: Implement signals.go (interface + Trakt adapter)**
+
+Create `lib/recommend/signals.go`:
+
+```go
+package recommend
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strconv"
+	"time"
+
+	"github.com/icco/gutil/logging"
+	"github.com/icco/recommender/lib/trakt"
+	"github.com/icco/recommender/models"
+	"go.uber.org/zap"
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+)
+
+// SignalSource fetches external data and upserts ExternalSignal rows joined to
+// owned Plex titles. Name is the models.Source* value it writes.
+type SignalSource interface {
+	Name() string
+	Sync(ctx context.Context) (int, error)
+}
+
+// upsertSignal inserts or updates a signal on its (source, external_ref, kind) key.
+func upsertSignal(ctx context.Context, db *gorm.DB, sig models.ExternalSignal) error {
+	sig.UpdatedAt = time.Now()
+	return db.WithContext(ctx).Clauses(clause.OnConflict{
+		Columns:   []clause.Column{{Name: "source"}, {Name: "external_ref"}, {Name: "kind"}},
+		DoUpdates: clause.AssignmentColumns([]string{"value", "movie_id", "tvshow_id", "updated_at"}),
+	}).Create(&sig).Error
+}
+
+// matchPlexID resolves external identifiers to an owned Plex movie or TV show,
+// preferring TMDb, then IMDb, then TVDb. Returns (nil, nil) if not owned.
+func matchPlexID(ctx context.Context, db *gorm.DB, tmdb *int, imdb, tvdb string, isShow bool) (movieID, tvID *uint) {
+	find := func(q *gorm.DB) *uint {
+		if isShow {
+			var s models.TVShow
+			if err := q.First(&s).Error; err == nil {
+				return &s.ID
+			}
+			return nil
+		}
+		var m models.Movie
+		if err := q.First(&m).Error; err == nil {
+			return &m.ID
+		}
+		return nil
+	}
+	table := db.WithContext(ctx).Model(&models.Movie{})
+	if isShow {
+		table = db.WithContext(ctx).Model(&models.TVShow{})
+	}
+	var id *uint
+	if tmdb != nil && *tmdb > 0 {
+		id = find(table.Session(&gorm.Session{}).Where("tm_db_id = ?", *tmdb))
+	}
+	if id == nil && imdb != "" {
+		id = find(table.Session(&gorm.Session{}).Where("im_db_id = ?", imdb))
+	}
+	if id == nil && tvdb != "" {
+		id = find(table.Session(&gorm.Session{}).Where("tv_db_id = ?", tvdb))
+	}
+	if isShow {
+		return nil, id
+	}
+	return id, nil
+}
+
+// traktSource syncs Trakt watched/ratings/watchlist into ExternalSignal rows.
+type traktSource struct {
+	db     *gorm.DB
+	client *trakt.Client
+}
+
+func (s *traktSource) Name() string { return models.SourceTrakt }
+
+// syncPath maps a Trakt sync endpoint to the signal kind it produces.
+type syncPath struct {
+	path string
+	kind string
+}
+
+var traktPaths = []syncPath{
+	{"sync/watched/movies", models.SignalKindWatched},
+	{"sync/watched/shows", models.SignalKindWatched},
+	{"sync/ratings/movies", models.SignalKindRated},
+	{"sync/ratings/shows", models.SignalKindRated},
+	{"sync/watchlist/movies", models.SignalKindWatchlist},
+	{"sync/watchlist/shows", models.SignalKindWatchlist},
+}
+
+// Sync fetches all Trakt sync endpoints, joins to owned Plex titles, and upserts
+// signals. A valid access token is required (see ensureTraktToken).
+func (s *traktSource) Sync(ctx context.Context) (int, error) {
+	l := logging.FromContext(ctx)
+	token, err := s.accessToken(ctx)
+	if err != nil {
+		return 0, err
+	}
+	count := 0
+	for _, sp := range traktPaths {
+		rows, err := s.client.Sync(ctx, token, sp.path)
+		if err != nil {
+			l.Warnw("trakt sync path failed", "path", sp.path, zap.Error(err))
+			continue
+		}
+		for _, row := range rows {
+			media := row.Movie
+			isShow := false
+			if media == nil {
+				media = row.Show
+				isShow = true
+			}
+			if media == nil {
+				continue
+			}
+			movieID, tvID := matchPlexID(ctx, s.db, nilIfZero(media.IDs.TMDb), media.IDs.IMDb, itoaOrEmpty(media.IDs.TVDb), isShow)
+			if movieID == nil && tvID == nil {
+				continue // not owned
+			}
+			value := 1.0
+			if sp.kind == models.SignalKindRated {
+				value = float64(row.Rating)
+			}
+			ref := fmt.Sprintf("%s:%d", sp.kind, media.IDs.Trakt)
+			if err := upsertSignal(ctx, s.db, models.ExternalSignal{
+				Source: models.SourceTrakt, ExternalRef: ref, Kind: sp.kind,
+				MovieID: movieID, TVShowID: tvID, Value: value,
+			}); err != nil {
+				l.Warnw("upsert trakt signal failed", "ref", ref, zap.Error(err))
+				continue
+			}
+			count++
+		}
+	}
+	return count, nil
+}
+
+// accessToken returns a valid Trakt access token, refreshing if expired.
+func (s *traktSource) accessToken(ctx context.Context) (string, error) {
+	var tok models.OAuthToken
+	err := s.db.WithContext(ctx).Where("source = ?", models.SourceTrakt).First(&tok).Error
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		return "", fmt.Errorf("trakt not connected; visit /trakt/connect")
+	}
+	if err != nil {
+		return "", fmt.Errorf("load trakt token: %w", err)
+	}
+	if time.Now().Before(tok.ExpiresAt.Add(-1 * time.Minute)) {
+		return tok.AccessToken, nil
+	}
+	refreshed, err := s.client.RefreshToken(ctx, tok.RefreshToken)
+	if err != nil {
+		return "", fmt.Errorf("refresh trakt token: %w", err)
+	}
+	if err := s.saveToken(ctx, refreshed); err != nil {
+		return "", err
+	}
+	return refreshed.AccessToken, nil
+}
+
+// saveToken upserts the Trakt token row.
+func (s *traktSource) saveToken(ctx context.Context, tok *trakt.Token) error {
+	row := models.OAuthToken{
+		Source: models.SourceTrakt, AccessToken: tok.AccessToken,
+		RefreshToken: tok.RefreshToken, ExpiresAt: tok.ExpiresAt(), UpdatedAt: time.Now(),
+	}
+	return s.db.WithContext(ctx).Clauses(clause.OnConflict{
+		Columns:   []clause.Column{{Name: "source"}},
+		DoUpdates: clause.AssignmentColumns([]string{"access_token", "refresh_token", "expires_at", "updated_at"}),
+	}).Create(&row).Error
+}
+
+func nilIfZero(n int) *int {
+	if n == 0 {
+		return nil
+	}
+	return &n
+}
+
+func itoaOrEmpty(n int) string {
+	if n == 0 {
+		return ""
+	}
+	return strconv.Itoa(n)
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `go test ./lib/recommend/... -run TestTraktSource_Sync -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/recommend/signals.go lib/recommend/signals_test.go
+git commit -m "feat: SignalSource interface and Trakt adapter with token refresh
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 5: AniList adapter
+
+**Files:** Modify `lib/recommend/signals.go`, `lib/recommend/signals_test.go`.
+
+**Interfaces:**
+- Produces: `type anilistSource struct { db *gorm.DB; client *anilist.Client; username string }`; `Name()` → `models.SourceAniList`; `Sync(ctx) (int, error)`.
+
+- [ ] **Step 1: Write the test**
+
+Add to `lib/recommend/signals_test.go`:
+
+```go
+func TestAniListSource_Sync_matchesByTitleYear(t *testing.T) {
+	db := testDB(t)
+	ctx := context.Background()
+	if err := db.Create(&models.TVShow{Title: "Demon Slayer", Year: 2019, PlexRatingKey: "s1"}).Error; err != nil {
+		t.Fatal(err)
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"data":{"User":{"mediaListOptions":{"scoreFormat":"POINT_10"}},
+			"MediaListCollection":{"lists":[{"entries":[
+				{"score":9,"media":{"seasonYear":2019,"title":{"romaji":"Kimetsu","english":"Demon Slayer"}}},
+				{"score":9,"media":{"seasonYear":1990,"title":{"romaji":"Nope","english":"Not Owned"}}}
+			]}]}}}}`))
+	}))
+	defer srv.Close()
+
+	c := anilist.NewClient()
+	c.URL = srv.URL
+	s := &anilistSource{db: db, client: c, username: "nat"}
+	n, err := s.Sync(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n != 1 {
+		t.Fatalf("expected 1 matched signal, got %d", n)
+	}
+	var sigs []models.ExternalSignal
+	db.Where("source = ?", models.SourceAniList).Find(&sigs)
+	if len(sigs) != 1 || sigs[0].TVShowID == nil || sigs[0].Value != 9 {
+		t.Fatalf("bad anilist signals: %+v", sigs)
+	}
+}
+```
+
+Add `"github.com/icco/recommender/lib/anilist"` to the test's imports.
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `go test ./lib/recommend/... -run TestAniListSource_Sync -v`
+Expected: FAIL (undefined `anilistSource`).
+
+- [ ] **Step 3: Implement the AniList adapter**
+
+Add to `lib/recommend/signals.go` (add `"github.com/icco/recommender/lib/anilist"` and `"strings"` to imports):
+
+```go
+// anilistSource syncs a user's AniList anime scores, matched to owned Plex titles
+// by title + year.
+type anilistSource struct {
+	db       *gorm.DB
+	client   *anilist.Client
+	username string
+}
+
+func (s *anilistSource) Name() string { return models.SourceAniList }
+
+// Sync fetches the AniList list and upserts score signals for titles owned in Plex.
+func (s *anilistSource) Sync(ctx context.Context) (int, error) {
+	l := logging.FromContext(ctx)
+	entries, err := s.client.List(ctx, s.username)
+	if err != nil {
+		return 0, fmt.Errorf("anilist list: %w", err)
+	}
+	count := 0
+	for _, e := range entries {
+		movieID, tvID := matchByTitleYear(ctx, s.db, e.Title, e.Year)
+		if movieID == nil && tvID == nil {
+			continue
+		}
+		ref := fmt.Sprintf("score:%s:%d", strings.ToLower(e.Title), e.Year)
+		if err := upsertSignal(ctx, s.db, models.ExternalSignal{
+			Source: models.SourceAniList, ExternalRef: ref, Kind: models.SignalKindScore,
+			MovieID: movieID, TVShowID: tvID, Value: e.Score,
+		}); err != nil {
+			l.Warnw("upsert anilist signal failed", "ref", ref, zap.Error(err))
+			continue
+		}
+		count++
+	}
+	l.Infow("anilist sync", "entries", len(entries), "matched", count)
+	return count, nil
+}
+
+// matchByTitleYear finds an owned Plex title by case-insensitive title + year,
+// checking TV shows first (anime are usually series), then movies.
+func matchByTitleYear(ctx context.Context, db *gorm.DB, title string, year int) (movieID, tvID *uint) {
+	var show models.TVShow
+	if err := db.WithContext(ctx).Where("title = ? COLLATE NOCASE AND year = ?", title, year).First(&show).Error; err == nil {
+		return nil, &show.ID
+	}
+	var movie models.Movie
+	if err := db.WithContext(ctx).Where("title = ? COLLATE NOCASE AND year = ?", title, year).First(&movie).Error; err == nil {
+		return &movie.ID, nil
+	}
+	return nil, nil
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `go test ./lib/recommend/... -run 'TestAniListSource_Sync|TestTraktSource_Sync' -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/recommend/signals.go lib/recommend/signals_test.go
+git commit -m "feat: AniList adapter matching anime scores to owned Plex titles
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 6: SyncSignals + wiring (New config, HandleCache, main)
+
+**Files:** Modify `lib/recommend/signals.go`, `lib/recommend/recommend.go`, `handlers/handlers.go`, `main.go`.
+
+**Interfaces:**
+- Produces:
+  - `type SignalConfig struct { TraktClientID, TraktClientSecret, AniListUsername string }`
+  - `New(db, plex, tmdb, chat, model, sigCfg SignalConfig)` (extended signature)
+  - `Recommender` fields `sigCfg SignalConfig`
+  - `func (r *Recommender) SyncSignals(ctx context.Context)` — best-effort over configured sources
+  - `func (r *Recommender) traktClient() *trakt.Client` (nil if unconfigured)
+  - `HandleCache(p *plex.Client, r *recommend.Recommender, fl *lock.FileLock)`
+
+- [ ] **Step 1: Add SignalConfig + SyncSignals**
+
+In `lib/recommend/recommend.go`, add the field and extend `New`:
+
+```go
+type Recommender struct {
+	db     *gorm.DB
+	plex   *plex.Client
+	tmdb   *tmdb.Client
+	chat   Chatter
+	model  string
+	sigCfg SignalConfig
+}
+
+func New(db *gorm.DB, plexClient *plex.Client, tmdbClient *tmdb.Client, chat Chatter, model string, sigCfg SignalConfig) (*Recommender, error) {
+	return &Recommender{db: db, plex: plexClient, tmdb: tmdbClient, chat: chat, model: model, sigCfg: sigCfg}, nil
+}
+```
+
+In `lib/recommend/signals.go`, add (import `"github.com/icco/recommender/lib/anilist"` already present; add nothing new):
+
+```go
+// SignalConfig holds credentials/usernames for external signal sources. Empty
+// fields disable that source.
+type SignalConfig struct {
+	TraktClientID     string
+	TraktClientSecret string
+	AniListUsername   string
+}
+
+// traktClient returns a Trakt client if credentials are configured, else nil.
+func (r *Recommender) traktClient() *trakt.Client {
+	if r.sigCfg.TraktClientID == "" || r.sigCfg.TraktClientSecret == "" {
+		return nil
+	}
+	return trakt.NewClient(r.sigCfg.TraktClientID, r.sigCfg.TraktClientSecret)
+}
+
+// configuredSources returns the enabled signal sources.
+func (r *Recommender) configuredSources() []SignalSource {
+	var out []SignalSource
+	if c := r.traktClient(); c != nil {
+		out = append(out, &traktSource{db: r.db, client: c})
+	}
+	if r.sigCfg.AniListUsername != "" {
+		out = append(out, &anilistSource{db: r.db, client: anilist.NewClient(), username: r.sigCfg.AniListUsername})
+	}
+	return out
+}
+
+// SyncSignals runs every configured source best-effort; failures are logged.
+func (r *Recommender) SyncSignals(ctx context.Context) {
+	l := logging.FromContext(ctx)
+	for _, src := range r.configuredSources() {
+		n, err := src.Sync(ctx)
+		if err != nil {
+			l.Warnw("signal source sync failed", "source", src.Name(), zap.Error(err))
+			continue
+		}
+		l.Infow("signal source synced", "source", src.Name(), "count", n)
+	}
+}
+```
+
+- [ ] **Step 2: Update main.go wiring**
+
+In `main.go`, after `geminiModel` is resolved and before `recommend.New`, read env and build config:
+
+```go
+	sigCfg := recommend.SignalConfig{
+		TraktClientID:     os.Getenv("TRAKT_CLIENT_ID"),
+		TraktClientSecret: os.Getenv("TRAKT_CLIENT_SECRET"),
+		AniListUsername:   os.Getenv("ANILIST_USERNAME"),
+	}
+```
+
+Change the constructor call to `recommend.New(gormDB, plexClient, tmdbClient, chat, geminiModel, sigCfg)`. Change the cache route to `r.Get("/cron/cache", handlers.HandleCache(plexClient, recommender, fileLock))`.
+
+- [ ] **Step 3: Run SyncSignals from HandleCache**
+
+In `handlers/handlers.go`, change the signature to `func HandleCache(p *plex.Client, rec *recommend.Recommender, fl *lock.FileLock) http.HandlerFunc` and, inside the background goroutine, after the successful `p.UpdateCache(bgCtx)` block, add a signal sync. Replace:
+
+```go
+			if err := p.UpdateCache(bgCtx); err != nil {
+				l.Errorw("Failed to update cache", zap.Error(err))
+			} else {
+				l.Infow("Cache update completed successfully",
+					"duration", time.Since(startTime),
+				)
+			}
+```
+
+with:
+
+```go
+			if err := p.UpdateCache(bgCtx); err != nil {
+				l.Errorw("Failed to update cache", zap.Error(err))
+			} else {
+				l.Infow("Cache update completed successfully",
+					"duration", time.Since(startTime),
+				)
+				rec.SyncSignals(bgCtx)
+			}
+```
+
+- [ ] **Step 4: Build and test**
+
+Run: `go build ./... && go test ./lib/recommend/... ./...`
+Expected: build OK; tests PASS. (Existing recommend tests construct `Recommender` via struct literal, so the `New` signature change doesn't break them; `main.go` is the only `New` caller.)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/recommend/recommend.go lib/recommend/signals.go handlers/handlers.go main.go
+git commit -m "feat: SyncSignals wired into cache cron and app config
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 7: Trakt device-flow connect endpoint
+
+**Files:** Modify `lib/recommend/signals.go`, `handlers/handlers.go`, `main.go`; Test `lib/recommend/signals_test.go`.
+
+**Interfaces:**
+- Produces:
+  - `func (r *Recommender) TraktConnect(ctx) (userCode, verificationURL string, err error)` — starts device flow, spawns a background poll that stores the token.
+  - `func (r *Recommender) storeTraktToken(ctx, *trakt.Token) error` (used by the poll; wraps `traktSource.saveToken`).
+  - `HandleTraktConnect(r *recommend.Recommender) http.HandlerFunc` → `GET /trakt/connect`.
+
+- [ ] **Step 1: Write a token-store test**
+
+Add to `lib/recommend/signals_test.go`:
+
+```go
+func TestStoreTraktToken_upserts(t *testing.T) {
+	db := testDB(t)
+	r := &Recommender{db: db, sigCfg: SignalConfig{TraktClientID: "a", TraktClientSecret: "b"}}
+	ctx := context.Background()
+	if err := r.storeTraktToken(ctx, &trakt.Token{AccessToken: "x", RefreshToken: "y", ExpiresIn: 3600, CreatedAt: 1700000000}); err != nil {
+		t.Fatal(err)
+	}
+	var tok models.OAuthToken
+	if err := db.Where("source = ?", models.SourceTrakt).First(&tok).Error; err != nil {
+		t.Fatal(err)
+	}
+	if tok.AccessToken != "x" {
+		t.Fatalf("bad token: %+v", tok)
+	}
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `go test ./lib/recommend/... -run TestStoreTraktToken -v`
+Expected: FAIL (undefined `storeTraktToken`).
+
+- [ ] **Step 3: Implement TraktConnect + storeTraktToken**
+
+Add to `lib/recommend/signals.go` (add `"time"` already imported):
+
+```go
+// storeTraktToken persists a Trakt token set.
+func (r *Recommender) storeTraktToken(ctx context.Context, tok *trakt.Token) error {
+	return (&traktSource{db: r.db}).saveToken(ctx, tok)
+}
+
+// TraktConnect starts the OAuth device flow and returns the user code + URL to
+// visit. A background goroutine polls until authorized and stores the token.
+func (r *Recommender) TraktConnect(ctx context.Context) (userCode, verificationURL string, err error) {
+	client := r.traktClient()
+	if client == nil {
+		return "", "", fmt.Errorf("trakt not configured (set TRAKT_CLIENT_ID/SECRET)")
+	}
+	dc, err := client.RequestDeviceCode(ctx)
+	if err != nil {
+		return "", "", fmt.Errorf("request device code: %w", err)
+	}
+	interval := time.Duration(dc.Interval) * time.Second
+	if interval <= 0 {
+		interval = 5 * time.Second
+	}
+	deadline := time.Now().Add(time.Duration(dc.ExpiresIn) * time.Second)
+
+	//nolint:contextcheck // background poll must outlive the request
+	go func() {
+		bg := logging.NewContext(context.Background(), logging.FromContext(ctx))
+		l := logging.FromContext(bg)
+		for time.Now().Before(deadline) {
+			time.Sleep(interval)
+			tok, perr := client.PollForToken(bg, dc.DeviceCode)
+			if perr != nil {
+				l.Warnw("trakt poll failed", zap.Error(perr))
+				return
+			}
+			if tok == nil {
+				continue // pending
+			}
+			if serr := r.storeTraktToken(bg, tok); serr != nil {
+				l.Errorw("store trakt token failed", zap.Error(serr))
+				return
+			}
+			l.Infow("trakt connected; token stored")
+			return
+		}
+		l.Warnw("trakt device code expired before authorization")
+	}()
+
+	return dc.UserCode, dc.VerificationURL, nil
+}
+```
+
+> `time.Sleep` in the poll loop is acceptable here (a detached background goroutine, not a request handler). If `revive`/`gocritic` flags it, keep it — it's the documented device-flow poll cadence.
+
+- [ ] **Step 4: Add the handler and route**
+
+In `handlers/handlers.go`, add:
+
+```go
+// HandleTraktConnect starts the Trakt OAuth device flow and returns the code to enter.
+func HandleTraktConnect(r *recommend.Recommender) http.HandlerFunc {
+	return func(w http.ResponseWriter, req *http.Request) {
+		ctx, cancel := context.WithTimeout(req.Context(), 15*time.Second)
+		defer cancel()
+		code, url, err := r.TraktConnect(ctx)
+		if err != nil {
+			writeError(w, req, err.Error(), http.StatusServiceUnavailable)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		if _, err := fmt.Fprintf(w, `{"message":"Go to %s and enter code %s","user_code":"%s","verification_url":"%s"}`,
+			url, code, code, url); err != nil {
+			logging.FromContext(ctx).Errorw("write trakt connect response", zap.Error(err))
+		}
+	}
+}
+```
+
+In `main.go`, register: `r.Get("/trakt/connect", handlers.HandleTraktConnect(recommender))`.
+
+- [ ] **Step 5: Run tests + build**
+
+Run: `go test ./lib/recommend/... -run TestStoreTraktToken -v && go build ./...`
+Expected: PASS + build OK.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add lib/recommend/signals.go lib/recommend/signals_test.go handlers/handlers.go main.go
+git commit -m "feat: /trakt/connect device-flow endpoint
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 8: Genre affinity blends signals
+
+**Files:** Modify `lib/recommend/profile.go`; Test `lib/recommend/profile_test.go`.
+
+**Interfaces:**
+- Consumes: `models.ExternalSignal` (`rated`/`score` kinds with `MovieID`/`TVShowID`).
+- Produces: `genreAffinity` now adds signal-weighted genre affinity (same normalized 0..1 return).
+
+- [ ] **Step 1: Write the test**
+
+Add to `lib/recommend/profile_test.go`:
+
+```go
+func TestGenreAffinity_blendsRatedSignals(t *testing.T) {
+	db := testDB(t)
+	r := testRecommender(db)
+	ctx := context.Background()
+
+	// One unwatched Comedy and one unwatched Horror, no Plex views/ratings.
+	comedy := models.Movie{Title: "C", Genre: "Comedy", Rating: 0, ViewCount: 0, PlexRatingKey: "a"}
+	horror := models.Movie{Title: "H", Genre: "Horror", Rating: 0, ViewCount: 0, PlexRatingKey: "b"}
+	db.Create(&comedy)
+	db.Create(&horror)
+	// A high external rating on the comedy should lift Comedy above Horror.
+	db.Create(&models.ExternalSignal{Source: models.SourceTrakt, ExternalRef: "rated:1", Kind: models.SignalKindRated, MovieID: &comedy.ID, Value: 10})
+
+	aff, err := r.genreAffinity(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if aff["Comedy"] <= aff["Horror"] {
+		t.Errorf("rated signal should lift Comedy (%.2f) above Horror (%.2f)", aff["Comedy"], aff["Horror"])
+	}
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `go test ./lib/recommend/... -run TestGenreAffinity_blendsRatedSignals -v`
+Expected: FAIL (Comedy == Horror == 0, both zero-rated).
+
+- [ ] **Step 3: Blend signals into genreAffinity**
+
+In `lib/recommend/profile.go`, replace the body of `genreAffinity` between building the Plex `raw` map and the normalization with a version that also folds in signals. Full replacement of the function:
+
+```go
+func (r *Recommender) genreAffinity(ctx context.Context) (map[string]float64, error) {
+	raw := make(map[string]float64)
+	movieGenres := make(map[uint][]string)
+	tvGenres := make(map[uint][]string)
+
+	accumulate := func(genres []string, rating float64, viewCount int) {
+		for _, g := range genres {
+			w := rating / 10.0
+			if viewCount > 0 {
+				w += 1.0
+			}
+			raw[g] += w
+		}
+	}
+
+	var movies []models.Movie
+	if err := r.db.WithContext(ctx).Find(&movies).Error; err != nil {
+		return nil, fmt.Errorf("affinity movies: %w", err)
+	}
+	for _, m := range movies {
+		g := splitGenres(m.Genre)
+		movieGenres[m.ID] = g
+		accumulate(g, m.Rating, m.ViewCount)
+	}
+	var shows []models.TVShow
+	if err := r.db.WithContext(ctx).Find(&shows).Error; err != nil {
+		return nil, fmt.Errorf("affinity shows: %w", err)
+	}
+	for _, s := range shows {
+		g := splitGenres(s.Genre)
+		tvGenres[s.ID] = g
+		accumulate(g, s.Rating, s.ViewCount)
+	}
+
+	// Fold in external rated/score signals: a high signal lifts its title's genres.
+	var sigs []models.ExternalSignal
+	if err := r.db.WithContext(ctx).
+		Where("kind IN ?", []string{models.SignalKindRated, models.SignalKindScore}).
+		Find(&sigs).Error; err != nil {
+		return nil, fmt.Errorf("affinity signals: %w", err)
+	}
+	for _, sig := range sigs {
+		var genres []string
+		switch {
+		case sig.MovieID != nil:
+			genres = movieGenres[*sig.MovieID]
+		case sig.TVShowID != nil:
+			genres = tvGenres[*sig.TVShowID]
+		}
+		for _, g := range genres {
+			raw[g] += sig.Value / 10.0
+		}
+	}
+
+	peak := 0.0
+	for _, v := range raw {
+		if v > peak {
+			peak = v
+		}
+	}
+	if peak == 0 {
+		return map[string]float64{}, nil
+	}
+	out := make(map[string]float64, len(raw))
+	for g, v := range raw {
+		out[g] = v / peak
+	}
+	return out, nil
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `go test ./lib/recommend/... -run TestGenreAffinity -v`
+Expected: PASS (both the existing Plex test and the new signals test).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/recommend/profile.go lib/recommend/profile_test.go
+git commit -m "feat: blend Trakt/AniList ratings into genre affinity
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 9: Watchlist boost + Trakt-watched-as-watched
+
+**Files:** Modify `lib/recommend/candidates.go`; Test `lib/recommend/candidates_test.go`.
+
+**Interfaces:**
+- Produces: `candidate.Watchlisted bool`; `scoreCandidate` adds `watchlistBoost` when set; `loadCandidates` marks watchlisted candidates, treats externally-watched movies as watched, and excludes externally-watched TV.
+- Consumes: `models.ExternalSignal` (`watchlist`/`watched`).
+
+- [ ] **Step 1: Write tests**
+
+Add to `lib/recommend/candidates_test.go`:
+
+```go
+func TestScoreCandidate_watchlistBoost(t *testing.T) {
+	base := mkCand(1, 7.0, 0)
+	boosted := base
+	boosted.Watchlisted = true
+	if scoreCandidate(boosted) <= scoreCandidate(base) {
+		t.Error("watchlisted candidate should score higher")
+	}
+}
+
+func TestLoadCandidates_externalWatched(t *testing.T) {
+	db := testDB(t)
+	r := testRecommender(db)
+	ctx := t.Context()
+	today := time.Date(2026, 7, 6, 0, 0, 0, 0, time.UTC)
+
+	movie := models.Movie{Title: "M", Year: 2000, Rating: 8, ViewCount: 0, PlexRatingKey: "m1"}
+	show := models.TVShow{Title: "S", Year: 2001, Rating: 8, ViewCount: 0, PlexRatingKey: "s1"}
+	db.Create(&movie)
+	db.Create(&show)
+	db.Create(&models.ExternalSignal{Source: models.SourceTrakt, ExternalRef: "watched:m", Kind: models.SignalKindWatched, MovieID: &movie.ID, Value: 1})
+	db.Create(&models.ExternalSignal{Source: models.SourceTrakt, ExternalRef: "watched:s", Kind: models.SignalKindWatched, TVShowID: &show.ID, Value: 1})
+
+	movies, tv, err := r.loadCandidates(ctx, today)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(tv) != 0 {
+		t.Errorf("externally-watched TV should be excluded, got %d", len(tv))
+	}
+	if len(movies) != 1 || movies[0].ViewCount == 0 {
+		t.Errorf("externally-watched movie should be treated as watched: %+v", movies)
+	}
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `go test ./lib/recommend/... -run 'TestScoreCandidate_watchlistBoost|TestLoadCandidates_externalWatched' -v`
+Expected: FAIL (`Watchlisted` undefined; external-watched not handled).
+
+- [ ] **Step 3: Add the field, boost, and signal sets**
+
+In `lib/recommend/candidates.go`, add `Watchlisted bool` to the `candidate` struct (after `Affinity`). Add the constant and boost in `scoreCandidate`:
+
+```go
+// watchlistBoost lifts titles the user has explicitly watchlisted externally.
+const watchlistBoost = 1.5
+
+func scoreCandidate(c candidate) float64 {
+	s := c.Rating / 10.0 * 2.0
+	if c.ViewCount == 0 {
+		s += 1.0
+	}
+	s += c.Affinity
+	if c.Watchlisted {
+		s += watchlistBoost
+	}
+	return s
+}
+```
+
+Add a helper to load signal ID sets, and use it in `loadCandidates`. Add near `recentlyRecommendedIDs`:
+
+```go
+// signalIDSet returns the Movie and TVShow IDs that have a signal of the given kind.
+func (r *Recommender) signalIDSet(ctx context.Context, kind string) (map[uint]struct{}, map[uint]struct{}, error) {
+	var sigs []models.ExternalSignal
+	if err := r.db.WithContext(ctx).Where("kind = ?", kind).Find(&sigs).Error; err != nil {
+		return nil, nil, fmt.Errorf("load %s signals: %w", kind, err)
+	}
+	m := make(map[uint]struct{})
+	tv := make(map[uint]struct{})
+	for _, s := range sigs {
+		if s.MovieID != nil {
+			m[*s.MovieID] = struct{}{}
+		}
+		if s.TVShowID != nil {
+			tv[*s.TVShowID] = struct{}{}
+		}
+	}
+	return m, tv, nil
+}
+```
+
+In `loadCandidates`, after the `affinityFor` closure, load the sets:
+
+```go
+	watchlistMovies, watchlistTV, err := r.signalIDSet(ctx, models.SignalKindWatchlist)
+	if err != nil {
+		return nil, nil, err
+	}
+	watchedMovies, watchedTV, err := r.signalIDSet(ctx, models.SignalKindWatched)
+	if err != nil {
+		return nil, nil, err
+	}
+```
+
+In the movie append loop, compute an effective view count and watchlist flag:
+
+```go
+		vc := m.ViewCount
+		if _, w := watchedMovies[m.ID]; w && vc == 0 {
+			vc = 1 // treat Trakt-watched as watched
+		}
+		_, wl := watchlistMovies[m.ID]
+		movies = append(movies, candidate{
+			ID: m.ID, Type: models.TypeMovie, Title: m.Title, Year: m.Year,
+			Rating: m.Rating, Genres: genres, PosterURL: m.PosterURL,
+			Runtime: m.Runtime, ViewCount: vc, TMDbID: m.TMDbID,
+			Affinity: affinityFor(genres), Watchlisted: wl,
+		})
+```
+
+In the TV loop, skip externally-watched shows and set the watchlist flag:
+
+```go
+		if _, skip := excludeTV[s.ID]; skip {
+			continue
+		}
+		if _, watched := watchedTV[s.ID]; watched {
+			continue // watched elsewhere; not a fresh TV pick
+		}
+		genres := splitGenres(s.Genre)
+		_, wl := watchlistTV[s.ID]
+		tvshows = append(tvshows, candidate{
+			ID: s.ID, Type: models.TypeTVShow, Title: s.Title, Year: s.Year,
+			Rating: s.Rating, Genres: genres, PosterURL: s.PosterURL,
+			Runtime: s.Seasons, ViewCount: s.ViewCount, TMDbID: s.TMDbID,
+			Affinity: affinityFor(genres), Watchlisted: wl,
+		})
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `go test ./lib/recommend/... -v`
+Expected: PASS (new tests + all existing).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/recommend/candidates.go lib/recommend/candidates_test.go
+git commit -m "feat: watchlist boost and Trakt-watched handling in candidate loading
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 10: Prompt context (recently loved)
+
+**Files:** Modify `lib/recommend/profile.go`, `lib/recommend/generate.go`, `lib/recommend/prompts/recommendation.txt`; Test `lib/recommend/profile_test.go`.
+
+**Interfaces:**
+- Produces: `func (r *Recommender) lovedTitles(ctx) (string, error)` — a one-line summary of highly-rated owned titles (Value ≥ 8), max 5; `promptData.Loved string`.
+
+- [ ] **Step 1: Write the test**
+
+Add to `lib/recommend/profile_test.go`:
+
+```go
+func TestLovedTitles_listsHighlyRated(t *testing.T) {
+	db := testDB(t)
+	r := testRecommender(db)
+	ctx := context.Background()
+	m := models.Movie{Title: "Loved Film", Year: 2000, PlexRatingKey: "a"}
+	db.Create(&m)
+	db.Create(&models.ExternalSignal{Source: models.SourceTrakt, ExternalRef: "rated:1", Kind: models.SignalKindRated, MovieID: &m.ID, Value: 10})
+
+	s, err := r.lovedTitles(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(s, "Loved Film") {
+		t.Errorf("expected loved summary to include the title, got %q", s)
+	}
+}
+```
+
+Add `"strings"` to the test imports if not present.
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `go test ./lib/recommend/... -run TestLovedTitles -v`
+Expected: FAIL (undefined `lovedTitles`).
+
+- [ ] **Step 3: Implement lovedTitles**
+
+Add to `lib/recommend/profile.go`:
+
+```go
+// lovedTitles summarizes up to 5 highly-rated (Value >= 8) owned titles from
+// external signals, for prompt context. Empty when there are none.
+func (r *Recommender) lovedTitles(ctx context.Context) (string, error) {
+	var sigs []models.ExternalSignal
+	if err := r.db.WithContext(ctx).
+		Where("kind IN ? AND value >= ?", []string{models.SignalKindRated, models.SignalKindScore}, 8.0).
+		Order("value DESC").Limit(20).Find(&sigs).Error; err != nil {
+		return "", fmt.Errorf("loved signals: %w", err)
+	}
+	seen := make(map[string]struct{})
+	var titles []string
+	for _, sig := range sigs {
+		var title string
+		if sig.MovieID != nil {
+			var m models.Movie
+			if err := r.db.WithContext(ctx).First(&m, *sig.MovieID).Error; err == nil {
+				title = m.Title
+			}
+		} else if sig.TVShowID != nil {
+			var s models.TVShow
+			if err := r.db.WithContext(ctx).First(&s, *sig.TVShowID).Error; err == nil {
+				title = s.Title
+			}
+		}
+		if title == "" {
+			continue
+		}
+		if _, dup := seen[title]; dup {
+			continue
+		}
+		seen[title] = struct{}{}
+		titles = append(titles, title)
+		if len(titles) == 5 {
+			break
+		}
+	}
+	if len(titles) == 0 {
+		return "", nil
+	}
+	return "Recently loved: " + strings.Join(titles, ", ") + ".", nil
+}
+```
+
+- [ ] **Step 4: Wire into the prompt**
+
+In `lib/recommend/generate.go`, add `Loved string` to `promptData`. In `renderPrompts`, after computing `profile`, add:
+
+```go
+	loved, err := r.lovedTitles(ctx)
+	if err != nil {
+		logging.FromContext(ctx).Warnw("loved titles failed; continuing without", zap.Error(err))
+		loved = ""
+	}
+```
+
+and pass `Loved: loved` in the `promptData` literal.
+
+In `lib/recommend/prompts/recommendation.txt`, add after the `{{if .Profile}}...{{end}}` block:
+
+```
+{{if .Loved}}{{.Loved}}
+{{end}}
+```
+
+- [ ] **Step 5: Run tests + build**
+
+Run: `go test ./lib/recommend/... -v && go build ./...`
+Expected: PASS + build OK.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add lib/recommend/profile.go lib/recommend/generate.go lib/recommend/prompts/recommendation.txt lib/recommend/profile_test.go
+git commit -m "feat: fold recently-loved titles into the recommendation prompt
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 11: Config + docs
+
+**Files:** Modify `README.md`, `template.env`, `CLAUDE.md`. Final verification.
+
+- [ ] **Step 1: template.env**
+
+Append to `template.env`:
+
+```
+# Optional signal sources (leave blank to disable)
+TRAKT_CLIENT_ID=
+TRAKT_CLIENT_SECRET=
+ANILIST_USERNAME=
+```
+
+- [ ] **Step 2: README.md**
+
+In the env-var table, add rows for `TRAKT_CLIENT_ID`, `TRAKT_CLIENT_SECRET` (no; enables Trakt signals), `ANILIST_USERNAME` (no; enables AniList signals). Add a short "Signal sources" subsection: Trakt needs a registered API app; after deploy, hit `GET /trakt/connect` once and enter the returned code at the Trakt URL to authorize; AniList only needs a public username. Note signals are synced during `/cron/cache` and only ever re-rank owned titles.
+
+- [ ] **Step 3: CLAUDE.md**
+
+Add the three env vars to both env-var lists, and a line under the recommendation-logic section: external signals (Trakt watched/ratings/watchlist, AniList scores) are synced in `/cron/cache` into `ExternalSignal` and consumed as genre affinity, watchlist boost, watched-handling, and prompt context.
+
+- [ ] **Step 4: Full verification**
+
+Run: `go build ./... && go test ./... && gofmt -l . && go vet ./...`
+Expected: build OK; all tests PASS; `gofmt -l .` empty; vet clean.
+
+- [ ] **Step 5: golangci-lint (if available)**
+
+Run: `golangci-lint run -E bodyclose,misspell,gosec,errorlint,noctx,contextcheck,nilerr,wastedassign,unparam,copyloopvar,intrange,revive,gocritic,unconvert`
+Expected: `0 issues`. Fix any findings (common ones: wrap `%w`, `defer Body.Close()`, `http.NewRequestWithContext`).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add README.md template.env CLAUDE.md
+git commit -m "docs: document Trakt and AniList signal sources
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Verification checklist (whole PR)
+
+- [ ] `go build ./...`, `go test ./...`, `gofmt -l .`, `go vet ./...`, golangci-lint all clean.
+- [ ] Trakt + AniList unconfigured → app builds/runs; `SyncSignals` is a no-op; recommendations still generate.
+- [ ] `TestTraktSource_Sync`, `TestAniListSource_Sync` join by ID / title+year and drop unmatched.
+- [ ] `genreAffinity` blends signals; watchlist boost reorders; externally-watched TV excluded and movies treated as watched; `lovedTitles` appears in the prompt.
+- [ ] No network in the unit suite (all via httptest / in-memory DB).
+- [ ] Manual (needs creds): set `TRAKT_CLIENT_ID/SECRET`, `curl /trakt/connect`, authorize; set `ANILIST_USERNAME`; run `/cron/cache`; confirm `external_signals` populated; run `/cron/recommend`.
+
+## Notes for the implementer
+
+- Tasks 4–7 all touch `signals.go`; implement in order and commit at each boundary.
+- The `New` signature changes in Task 6; only `main.go` calls it (tests build `Recommender` literals), so the blast radius is small.
+- Keep signal weights (`watchlistBoost`, the `/10` affinity factor) as named constants for tuning.
+- Trakt/AniList clients expose `BaseURL`/`URL` fields specifically so tests point them at `httptest` servers — never hit the real APIs in tests.

--- a/docs/superpowers/specs/2026-07-06-signal-sources-design.md
+++ b/docs/superpowers/specs/2026-07-06-signal-sources-design.md
@@ -1,0 +1,141 @@
+# External Signal Sources (Trakt + AniList) — Design
+
+**Date:** 2026-07-06
+**Status:** Approved (design). Ships as a **single PR** (Phases 3 + 4 of the overhaul roadmap).
+
+## Problem
+
+The recommender personalizes only from Plex watch counts + Plex ratings
+(`genreAffinity` in `lib/recommend/profile.go`). Real taste lives in external
+services — Trakt (watch history, ratings, watchlist) and AniList (anime scores).
+Phase 1 added the plumbing (`ExternalSignal` table, `Movie`/`TVShow` IMDb/TMDb/
+TVDb IDs) but nothing populates or consumes it yet.
+
+## Goal
+
+Feed Trakt and AniList signals into recommendations. **Signals only rank
+Plex-owned titles** — every recommendation remains something you own. Both
+sources are **optional**: unconfigured → skipped, the app runs unchanged.
+
+## Non-goals
+
+- No recommending titles you don't own (no discovery/where-to-watch).
+- No storing signals that don't join to an owned Plex title.
+- No AniList OAuth (public lists only).
+
+## Architecture
+
+```
+/cron/cache  Plex upsert (existing)
+           → SyncSignals(ctx): for each configured SignalSource, fetch + upsert
+             ExternalSignal rows joined to Plex by TMDb→IMDb→TVDb (best-effort)
+
+/cron/recommend  loadCandidates now folds in signals:
+             - genre affinity blends Plex behavior + rated/score signals
+             - watchlist boost on owned titles
+             - Trakt-watched treated as watched (novelty/rewatch, TV exclusion)
+           → prompt gets a short "recently loved" context line
+```
+
+### Components
+- `lib/trakt/client.go` — Trakt HTTP client: OAuth device flow, token refresh,
+  and the `sync/*` endpoints. Typed responses; no DB access.
+- `lib/anilist/client.go` — AniList GraphQL client: `MediaListCollection` by
+  username. Typed responses; no DB access.
+- `lib/recommend/signals.go` — the `SignalSource` interface, the Trakt and
+  AniList adapters (call the client, join to Plex, upsert `ExternalSignal`), and
+  `SyncSignals(ctx)` which runs every configured source best-effort.
+- `lib/recommend/profile.go` / `candidates.go` — extended to consume signals.
+
+### SignalSource interface
+```go
+type SignalSource interface {
+    Name() string
+    Sync(ctx context.Context) (synced int, err error)
+}
+```
+`SyncSignals` iterates the configured sources; a source error is logged and does
+not fail the others or the cache job.
+
+## Signal consumption
+
+All signals reference an owned Plex row (`MovieID`/`TVShowID` set). Four effects:
+
+1. **Genre affinity.** `genreAffinity` adds, per `rated`/`score` signal, a weight
+   `Value/10` to the joined title's genres — blended with the existing Plex
+   watch/rating weighting. Higher-rated titles pull their genres up.
+2. **Watchlist boost.** `loadCandidates` marks candidates that have a
+   `watchlist` signal; `scoreCandidate` adds a fixed boost so watchlisted owned
+   titles rank higher.
+3. **Trakt-watched = watched.** Titles with a `watched` signal are treated as
+   watched even when Plex `ViewCount == 0`: movies lose the unwatched novelty
+   boost and become rewatch-slot eligible; such TV shows are excluded from the TV
+   candidate pool (which is otherwise `ViewCount == 0`).
+4. **Prompt context.** A one-line "recently loved on Trakt/AniList: …" summary
+   (top few highly-rated owned titles) is folded into the prompt next to the
+   taste profile.
+
+## Trakt
+
+- **Auth:** OAuth device flow. Env `TRAKT_CLIENT_ID` / `TRAKT_CLIENT_SECRET`
+  (unset → Trakt skipped). `GET /trakt/connect` starts the flow, returns the
+  `user_code` + `verification_url`, and background-polls `oauth/device/token`
+  until authorized. Tokens persist in a new `OAuthToken` row and refresh before
+  each sync. `/trakt/connect` is unauthenticated; completing the flow still
+  requires a Trakt login, so it cannot be hijacked (can be gated later if
+  desired).
+- **Sync:** `sync/watched/movies`, `sync/watched/shows`, `sync/ratings/movies`,
+  `sync/ratings/shows`, `sync/watchlist/movies`, `sync/watchlist/shows`. Each
+  item carries `ids.{trakt,imdb,tmdb,tvdb}`. Map to `ExternalSignal`:
+  - watched → `Kind=watched`, `Value=1`
+  - ratings → `Kind=rated`, `Value=<1..10>`
+  - watchlist → `Kind=watchlist`, `Value=1`
+  Join by TMDb→IMDb→TVDb; drop items not owned in Plex.
+
+## AniList
+
+- **Auth:** none. Env `ANILIST_USERNAME` (unset → AniList skipped).
+- **Sync:** GraphQL `MediaListCollection(userName, type: ANIME)` → entries with
+  `score` (normalized to 0..10) and media `{ idMal, title, seasonYear, format }`.
+  Best-effort match to Plex by title + year (and IDs where available). Store
+  matched entries as `ExternalSignal{Source:"anilist", Kind:score, Value:<0..10>}`;
+  drop unmatched.
+
+## Data model / config
+
+- New `OAuthToken{ID, Source (unique), AccessToken, RefreshToken, ExpiresAt,
+  UpdatedAt}` (Trakt only). Added to `AutoMigrate`.
+- `ExternalSignal` reused unchanged.
+- Env (all optional): `TRAKT_CLIENT_ID`, `TRAKT_CLIENT_SECRET`, `ANILIST_USERNAME`.
+- `SourceTrakt = "trakt"`, `SourceAniList = "anilist"` constants added to `models`.
+
+## Error handling
+
+- Per-source sync isolated; failures logged, others continue, cache job succeeds.
+- Trakt token refresh failure → log, skip Trakt this run (recommendations still
+  generate from Plex + AniList + prior signals).
+- Unmatched titles skipped silently (expected, not errors).
+
+## Testing
+
+- Trakt client: `httptest` for device-flow bootstrap, token refresh, and each
+  `sync/*` endpoint.
+- AniList client: `httptest` for the GraphQL response.
+- Signal adapters: in-memory DB; feed fake client data; assert `ExternalSignal`
+  rows are joined and upserted correctly, and unmatched items dropped.
+- Consumption: affinity blends signal weight; watchlist boost reorders; a
+  Trakt-`watched` movie loses novelty and a watched TV show leaves the pool; the
+  prompt-context string includes loved titles.
+- No network in the unit suite; sources gated off when env is unset.
+
+## Risks / open questions
+
+- **AniList matching accuracy.** Title+year matching for anime is imperfect
+  (romaji vs english titles, season splits). Acceptable: unmatched entries are
+  dropped, so the failure mode is "no signal," never a wrong signal. Log matched
+  vs total counts.
+- **Trakt device-flow bootstrap on a headless host.** `/trakt/connect` must be
+  reachable once to authorize; the token then persists in the DB volume. If the
+  DB is wiped, re-run `/trakt/connect`.
+- **Signal weighting balance.** Blending Plex + Trakt + AniList affinity and the
+  watchlist boost may need tuning; keep the boost/weights as named constants.

--- a/handlers/handlers.go
+++ b/handlers/handlers.go
@@ -392,7 +392,7 @@ func HandleCron(r *recommend.Recommender, fl *lock.FileLock) http.HandlerFunc {
 // background timeout fires.
 //
 //nolint:contextcheck // background cache job + deferred Unlock intentionally use a
-func HandleCache(p *plex.Client, fl *lock.FileLock) http.HandlerFunc {
+func HandleCache(p *plex.Client, rec *recommend.Recommender, fl *lock.FileLock) http.HandlerFunc {
 	return func(w http.ResponseWriter, req *http.Request) {
 		ctx := req.Context()
 		l := logging.FromContext(ctx)
@@ -452,6 +452,7 @@ func HandleCache(p *plex.Client, fl *lock.FileLock) http.HandlerFunc {
 				l.Infow("Cache update completed successfully",
 					"duration", time.Since(startTime),
 				)
+				rec.SyncSignals(bgCtx)
 			}
 		}()
 

--- a/handlers/handlers.go
+++ b/handlers/handlers.go
@@ -483,3 +483,21 @@ func HandleStats(r *recommend.Recommender) http.HandlerFunc {
 		}
 	}
 }
+
+// HandleTraktConnect starts the Trakt OAuth device flow and returns the code to enter.
+func HandleTraktConnect(r *recommend.Recommender) http.HandlerFunc {
+	return func(w http.ResponseWriter, req *http.Request) {
+		ctx, cancel := context.WithTimeout(req.Context(), 15*time.Second)
+		defer cancel()
+		code, url, err := r.TraktConnect(ctx)
+		if err != nil {
+			writeError(w, req, err.Error(), http.StatusServiceUnavailable)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		if _, err := fmt.Fprintf(w, `{"message":"Go to %s and enter code %s","user_code":"%s","verification_url":"%s"}`,
+			url, code, code, url); err != nil {
+			logging.FromContext(ctx).Errorw("write trakt connect response", zap.Error(err))
+		}
+	}
+}

--- a/handlers/handlers.go
+++ b/handlers/handlers.go
@@ -4,6 +4,7 @@ package handlers
 
 import (
 	"context"
+	"crypto/subtle"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -485,8 +486,19 @@ func HandleStats(r *recommend.Recommender) http.HandlerFunc {
 }
 
 // HandleTraktConnect starts the Trakt OAuth device flow and returns the code to enter.
-func HandleTraktConnect(r *recommend.Recommender) http.HandlerFunc {
+// It is gated by a shared secret: the endpoint mints/stores an OAuth token (whoever
+// completes the flow decides which Trakt account is stored), so it is disabled unless
+// connectToken is set and matched via the "token" query parameter.
+func HandleTraktConnect(r *recommend.Recommender, connectToken string) http.HandlerFunc {
 	return func(w http.ResponseWriter, req *http.Request) {
+		if connectToken == "" {
+			writeError(w, req, "endpoint disabled; set TRAKT_CONNECT_TOKEN to enable", http.StatusServiceUnavailable)
+			return
+		}
+		if subtle.ConstantTimeCompare([]byte(req.URL.Query().Get("token")), []byte(connectToken)) != 1 {
+			writeError(w, req, "unauthorized", http.StatusUnauthorized)
+			return
+		}
 		ctx, cancel := context.WithTimeout(req.Context(), 15*time.Second)
 		defer cancel()
 		code, url, err := r.TraktConnect(ctx)

--- a/handlers/handlers_test.go
+++ b/handlers/handlers_test.go
@@ -1,0 +1,32 @@
+package handlers
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/icco/recommender/lib/recommend"
+)
+
+func TestHandleTraktConnect_gate(t *testing.T) {
+	rec, err := recommend.New(nil, nil, nil, nil, "test", recommend.SignalConfig{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// No token configured → disabled.
+	h := HandleTraktConnect(rec, "")
+	w := httptest.NewRecorder()
+	h(w, httptest.NewRequest(http.MethodGet, "/trakt/connect", nil))
+	if w.Code != http.StatusServiceUnavailable {
+		t.Errorf("unset token: got %d, want 503", w.Code)
+	}
+
+	// Configured token, wrong value → unauthorized (before any device-flow work).
+	h = HandleTraktConnect(rec, "secret")
+	w = httptest.NewRecorder()
+	h(w, httptest.NewRequest(http.MethodGet, "/trakt/connect?token=nope", nil))
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("wrong token: got %d, want 401", w.Code)
+	}
+}

--- a/handlers/handlers_test.go
+++ b/handlers/handlers_test.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"context"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -17,7 +18,7 @@ func TestHandleTraktConnect_gate(t *testing.T) {
 	// No token configured → disabled.
 	h := HandleTraktConnect(rec, "")
 	w := httptest.NewRecorder()
-	h(w, httptest.NewRequest(http.MethodGet, "/trakt/connect", nil))
+	h(w, httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/trakt/connect", nil))
 	if w.Code != http.StatusServiceUnavailable {
 		t.Errorf("unset token: got %d, want 503", w.Code)
 	}
@@ -25,7 +26,7 @@ func TestHandleTraktConnect_gate(t *testing.T) {
 	// Configured token, wrong value → unauthorized (before any device-flow work).
 	h = HandleTraktConnect(rec, "secret")
 	w = httptest.NewRecorder()
-	h(w, httptest.NewRequest(http.MethodGet, "/trakt/connect?token=nope", nil))
+	h(w, httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/trakt/connect?token=nope", nil))
 	if w.Code != http.StatusUnauthorized {
 		t.Errorf("wrong token: got %d, want 401", w.Code)
 	}

--- a/lib/anilist/client.go
+++ b/lib/anilist/client.go
@@ -1,0 +1,133 @@
+// Package anilist is a minimal AniList GraphQL client for a user's public anime
+// list and scores, used as a recommendation ranking signal.
+package anilist
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+)
+
+const defaultURL = "https://graphql.anilist.co"
+
+// Client queries the public AniList GraphQL API. URL is overridable for tests.
+type Client struct {
+	URL        string
+	httpClient *http.Client
+}
+
+// NewClient returns an AniList client.
+func NewClient() *Client {
+	return &Client{URL: defaultURL, httpClient: &http.Client{Timeout: 30 * time.Second}}
+}
+
+// Entry is one rated anime from a user's list, score normalized to 0..10.
+type Entry struct {
+	Title string
+	Year  int
+	Score float64
+}
+
+const listQuery = `query($u:String){
+  User(name:$u){ mediaListOptions { scoreFormat } }
+  MediaListCollection(userName:$u, type:ANIME){ lists { entries {
+    score
+    media { seasonYear title { romaji english } }
+  } } }
+}`
+
+// List returns the user's rated anime (score > 0) with scores normalized to 0..10.
+func (c *Client) List(ctx context.Context, username string) ([]Entry, error) {
+	reqBody, err := json.Marshal(map[string]any{
+		"query":     listQuery,
+		"variables": map[string]string{"u": username},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("marshal query: %w", err)
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.URL, bytes.NewReader(reqBody))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	data, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode >= 400 {
+		return nil, fmt.Errorf("anilist: HTTP %d: %s", resp.StatusCode, string(data))
+	}
+
+	var out struct {
+		Data struct {
+			User struct {
+				MediaListOptions struct {
+					ScoreFormat string `json:"scoreFormat"`
+				} `json:"mediaListOptions"`
+			} `json:"User"`
+			MediaListCollection struct {
+				Lists []struct {
+					Entries []struct {
+						Score float64 `json:"score"`
+						Media struct {
+							SeasonYear int `json:"seasonYear"`
+							Title      struct {
+								Romaji  string `json:"romaji"`
+								English string `json:"english"`
+							} `json:"title"`
+						} `json:"media"`
+					} `json:"entries"`
+				} `json:"lists"`
+			} `json:"MediaListCollection"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(data, &out); err != nil {
+		return nil, fmt.Errorf("decode anilist: %w", err)
+	}
+
+	format := out.Data.User.MediaListOptions.ScoreFormat
+	var entries []Entry
+	for _, l := range out.Data.MediaListCollection.Lists {
+		for _, e := range l.Entries {
+			if e.Score <= 0 {
+				continue
+			}
+			title := e.Media.Title.English
+			if title == "" {
+				title = e.Media.Title.Romaji
+			}
+			if title == "" {
+				continue
+			}
+			entries = append(entries, Entry{
+				Title: title,
+				Year:  e.Media.SeasonYear,
+				Score: normalizeScore(e.Score, format),
+			})
+		}
+	}
+	return entries, nil
+}
+
+// normalizeScore maps AniList's per-user score format to a 0..10 scale.
+func normalizeScore(score float64, format string) float64 {
+	switch format {
+	case "POINT_100":
+		return score / 10.0
+	case "POINT_5":
+		return score * 2.0
+	case "POINT_3":
+		return score / 3.0 * 10.0
+	default: // POINT_10, POINT_10_DECIMAL
+		return score
+	}
+}

--- a/lib/anilist/client_test.go
+++ b/lib/anilist/client_test.go
@@ -1,0 +1,36 @@
+package anilist
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestList_normalizesScoresAndPicksTitle(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":{"User":{"mediaListOptions":{"scoreFormat":"POINT_100"}},
+			"MediaListCollection":{"lists":[{"entries":[
+				{"score":90,"media":{"seasonYear":2019,"title":{"romaji":"Kimetsu","english":"Demon Slayer"}}},
+				{"score":0,"media":{"seasonYear":2020,"title":{"romaji":"Unrated","english":null}}}
+			]}]}}}`))
+	}))
+	defer srv.Close()
+
+	c := NewClient()
+	c.URL = srv.URL
+	entries, err := c.List(context.Background(), "nat")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 rated entry, got %d (%+v)", len(entries), entries)
+	}
+	if entries[0].Title != "Demon Slayer" || entries[0].Year != 2019 {
+		t.Errorf("bad title/year: %+v", entries[0])
+	}
+	if entries[0].Score < 8.9 || entries[0].Score > 9.1 {
+		t.Errorf("POINT_100 90 should normalize to ~9.0, got %.2f", entries[0].Score)
+	}
+}

--- a/lib/anilist/client_test.go
+++ b/lib/anilist/client_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestList_normalizesScoresAndPicksTitle(t *testing.T) {
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(`{"data":{"User":{"mediaListOptions":{"scoreFormat":"POINT_100"}},
 			"MediaListCollection":{"lists":[{"entries":[

--- a/lib/db/migrations.go
+++ b/lib/db/migrations.go
@@ -49,7 +49,7 @@ func RunMigrations(ctx context.Context, db *gorm.DB) error {
 
 	if err := db.WithContext(ctx).AutoMigrate(
 		&models.Movie{}, &models.TVShow{}, &models.Recommendation{},
-		&models.GenerationRun{}, &models.ExternalSignal{},
+		&models.GenerationRun{}, &models.ExternalSignal{}, &models.OAuthToken{},
 	); err != nil {
 		return fmt.Errorf("failed to migrate database: %w", err)
 	}

--- a/lib/db/migrations_test.go
+++ b/lib/db/migrations_test.go
@@ -23,6 +23,9 @@ func TestRunMigrations_createsNewTables(t *testing.T) {
 	if !gdb.Migrator().HasTable(&models.ExternalSignal{}) {
 		t.Fatal("external_signals table missing")
 	}
+	if !gdb.Migrator().HasTable(&models.OAuthToken{}) {
+		t.Fatal("oauth_tokens table missing")
+	}
 	run := models.GenerationRun{Date: time.Now().UTC().Truncate(24 * time.Hour), Status: models.RunStatusOK, MovieCount: 4}
 	if err := gdb.Create(&run).Error; err != nil {
 		t.Fatalf("create run: %v", err)

--- a/lib/recommend/candidates.go
+++ b/lib/recommend/candidates.go
@@ -13,17 +13,18 @@ import (
 
 // candidate is a Plex-owned title eligible for recommendation, with a computed score.
 type candidate struct {
-	ID        uint
-	Type      string
-	Title     string
-	Year      int
-	Rating    float64
-	Genres    []string
-	PosterURL string
-	Runtime   int // minutes (movie) or seasons (tv)
-	ViewCount int
-	TMDbID    *int
-	Affinity  float64 // taste-profile boost (Phase 2); 0 otherwise
+	ID          uint
+	Type        string
+	Title       string
+	Year        int
+	Rating      float64
+	Genres      []string
+	PosterURL   string
+	Runtime     int // minutes (movie) or seasons (tv)
+	ViewCount   int
+	TMDbID      *int
+	Affinity    float64 // taste-profile boost (Phase 2); 0 otherwise
+	Watchlisted bool    // present on an external watchlist (Trakt)
 }
 
 // dateSeed derives a stable per-UTC-day seed so shortlists are reproducible.
@@ -32,14 +33,20 @@ func dateSeed(date time.Time) int64 {
 	return int64(y)*10000 + int64(m)*100 + int64(d)
 }
 
+// watchlistBoost lifts titles the user has explicitly watchlisted externally.
+const watchlistBoost = 1.5
+
 // scoreCandidate ranks a title: rating drives it, unwatched gets a novelty
-// boost, taste affinity adds on top.
+// boost, taste affinity and watchlist membership add on top.
 func scoreCandidate(c candidate) float64 {
 	s := c.Rating / 10.0 * 2.0
 	if c.ViewCount == 0 {
 		s += 1.0
 	}
 	s += c.Affinity
+	if c.Watchlisted {
+		s += watchlistBoost
+	}
 	return s
 }
 
@@ -103,6 +110,15 @@ func (r *Recommender) loadCandidates(ctx context.Context, date time.Time) (movie
 		return best
 	}
 
+	watchlistMovies, watchlistTV, err := r.signalIDSet(ctx, models.SignalKindWatchlist)
+	if err != nil {
+		return nil, nil, err
+	}
+	watchedMovies, watchedTV, err := r.signalIDSet(ctx, models.SignalKindWatched)
+	if err != nil {
+		return nil, nil, err
+	}
+
 	var dbMovies []models.Movie
 	if err := r.db.WithContext(ctx).Find(&dbMovies).Error; err != nil {
 		return nil, nil, fmt.Errorf("load movies: %w", err)
@@ -112,11 +128,16 @@ func (r *Recommender) loadCandidates(ctx context.Context, date time.Time) (movie
 			continue
 		}
 		genres := splitGenres(m.Genre)
+		vc := m.ViewCount
+		if _, w := watchedMovies[m.ID]; w && vc == 0 {
+			vc = 1 // treat Trakt-watched as watched
+		}
+		_, wl := watchlistMovies[m.ID]
 		movies = append(movies, candidate{
 			ID: m.ID, Type: models.TypeMovie, Title: m.Title, Year: m.Year,
 			Rating: m.Rating, Genres: genres, PosterURL: m.PosterURL,
-			Runtime: m.Runtime, ViewCount: m.ViewCount, TMDbID: m.TMDbID,
-			Affinity: affinityFor(genres),
+			Runtime: m.Runtime, ViewCount: vc, TMDbID: m.TMDbID,
+			Affinity: affinityFor(genres), Watchlisted: wl,
 		})
 	}
 
@@ -128,12 +149,16 @@ func (r *Recommender) loadCandidates(ctx context.Context, date time.Time) (movie
 		if _, skip := excludeTV[s.ID]; skip {
 			continue
 		}
+		if _, watched := watchedTV[s.ID]; watched {
+			continue // watched elsewhere; not a fresh TV pick
+		}
 		genres := splitGenres(s.Genre)
+		_, wl := watchlistTV[s.ID]
 		tvshows = append(tvshows, candidate{
 			ID: s.ID, Type: models.TypeTVShow, Title: s.Title, Year: s.Year,
 			Rating: s.Rating, Genres: genres, PosterURL: s.PosterURL,
 			Runtime: s.Seasons, ViewCount: s.ViewCount, TMDbID: s.TMDbID,
-			Affinity: affinityFor(genres),
+			Affinity: affinityFor(genres), Watchlisted: wl,
 		})
 	}
 	return movies, tvshows, nil
@@ -156,6 +181,25 @@ func (r *Recommender) recentlyRecommendedIDs(ctx context.Context, date time.Time
 		}
 		if rec.TVShowID != nil {
 			tv[*rec.TVShowID] = struct{}{}
+		}
+	}
+	return m, tv, nil
+}
+
+// signalIDSet returns the Movie and TVShow IDs that have a signal of the given kind.
+func (r *Recommender) signalIDSet(ctx context.Context, kind string) (map[uint]struct{}, map[uint]struct{}, error) {
+	var sigs []models.ExternalSignal
+	if err := r.db.WithContext(ctx).Where("kind = ?", kind).Find(&sigs).Error; err != nil {
+		return nil, nil, fmt.Errorf("load %s signals: %w", kind, err)
+	}
+	m := make(map[uint]struct{})
+	tv := make(map[uint]struct{})
+	for _, s := range sigs {
+		if s.MovieID != nil {
+			m[*s.MovieID] = struct{}{}
+		}
+		if s.TVShowID != nil {
+			tv[*s.TVShowID] = struct{}{}
 		}
 	}
 	return m, tv, nil

--- a/lib/recommend/candidates_test.go
+++ b/lib/recommend/candidates_test.go
@@ -106,3 +106,37 @@ func TestLoadCandidates_excludesRecentAndWatchedTV(t *testing.T) {
 		t.Errorf("tv = %+v, want only Fresh", tv)
 	}
 }
+
+func TestScoreCandidate_watchlistBoost(t *testing.T) {
+	base := mkCand(1, 7.0, 0)
+	boosted := base
+	boosted.Watchlisted = true
+	if scoreCandidate(boosted) <= scoreCandidate(base) {
+		t.Error("watchlisted candidate should score higher")
+	}
+}
+
+func TestLoadCandidates_externalWatched(t *testing.T) {
+	db := testDB(t)
+	r := testRecommender(db)
+	ctx := t.Context()
+	today := time.Date(2026, 7, 6, 0, 0, 0, 0, time.UTC)
+
+	movie := models.Movie{Title: "M", Year: 2000, Rating: 8, ViewCount: 0, PlexRatingKey: "m1"}
+	show := models.TVShow{Title: "S", Year: 2001, Rating: 8, ViewCount: 0, PlexRatingKey: "s1"}
+	db.Create(&movie)
+	db.Create(&show)
+	db.Create(&models.ExternalSignal{Source: models.SourceTrakt, ExternalRef: "watched:m", Kind: models.SignalKindWatched, MovieID: &movie.ID, Value: 1})
+	db.Create(&models.ExternalSignal{Source: models.SourceTrakt, ExternalRef: "watched:s", Kind: models.SignalKindWatched, TVShowID: &show.ID, Value: 1})
+
+	movies, tv, err := r.loadCandidates(ctx, today)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(tv) != 0 {
+		t.Errorf("externally-watched TV should be excluded, got %d", len(tv))
+	}
+	if len(movies) != 1 || movies[0].ViewCount == 0 {
+		t.Errorf("externally-watched movie should be treated as watched: %+v", movies)
+	}
+}

--- a/lib/recommend/generate.go
+++ b/lib/recommend/generate.go
@@ -27,6 +27,7 @@ type promptData struct {
 	TargetMovies  int
 	TargetTVShows int
 	Profile       string
+	Loved         string
 	Movies        string
 	TVShows       string
 }
@@ -120,14 +121,19 @@ func (r *Recommender) renderPrompts(ctx context.Context, movies, tvshows []candi
 	if err != nil {
 		return "", "", fmt.Errorf("parse user prompt: %w", err)
 	}
-	profile, err := r.tasteProfile(ctx) // Phase 2; returns "" until Task 8
+	profile, err := r.tasteProfile(ctx)
 	if err != nil {
 		logging.FromContext(ctx).Warnw("taste profile failed; continuing without", zap.Error(err))
 		profile = ""
 	}
+	loved, err := r.lovedTitles(ctx)
+	if err != nil {
+		logging.FromContext(ctx).Warnw("loved titles failed; continuing without", zap.Error(err))
+		loved = ""
+	}
 	var b strings.Builder
 	if err := userTmpl.Execute(&b, promptData{
-		TargetMovies: targetMovies, TargetTVShows: targetTVShows, Profile: profile,
+		TargetMovies: targetMovies, TargetTVShows: targetTVShows, Profile: profile, Loved: loved,
 		Movies: formatShortlist(movies), TVShows: formatShortlist(tvshows),
 	}); err != nil {
 		return "", "", fmt.Errorf("execute user prompt: %w", err)

--- a/lib/recommend/profile.go
+++ b/lib/recommend/profile.go
@@ -114,3 +114,46 @@ func (r *Recommender) tasteProfile(ctx context.Context) (string, error) {
 	}
 	return "Favorite genres, most to least: " + strings.Join(tops, ", ") + ".", nil
 }
+
+// lovedTitles summarizes up to 5 highly-rated (Value >= 8) owned titles from
+// external signals, for prompt context. Empty when there are none.
+func (r *Recommender) lovedTitles(ctx context.Context) (string, error) {
+	var sigs []models.ExternalSignal
+	if err := r.db.WithContext(ctx).
+		Where("kind IN ? AND value >= ?", []string{models.SignalKindRated, models.SignalKindScore}, 8.0).
+		Order("value DESC").Limit(20).Find(&sigs).Error; err != nil {
+		return "", fmt.Errorf("loved signals: %w", err)
+	}
+	seen := make(map[string]struct{})
+	var titles []string
+	for _, sig := range sigs {
+		var title string
+		switch {
+		case sig.MovieID != nil:
+			var m models.Movie
+			if err := r.db.WithContext(ctx).First(&m, *sig.MovieID).Error; err == nil {
+				title = m.Title
+			}
+		case sig.TVShowID != nil:
+			var s models.TVShow
+			if err := r.db.WithContext(ctx).First(&s, *sig.TVShowID).Error; err == nil {
+				title = s.Title
+			}
+		}
+		if title == "" {
+			continue
+		}
+		if _, dup := seen[title]; dup {
+			continue
+		}
+		seen[title] = struct{}{}
+		titles = append(titles, title)
+		if len(titles) == 5 {
+			break
+		}
+	}
+	if len(titles) == 0 {
+		return "", nil
+	}
+	return "Recently loved: " + strings.Join(titles, ", ") + ".", nil
+}

--- a/lib/recommend/profile.go
+++ b/lib/recommend/profile.go
@@ -13,9 +13,11 @@ import (
 // and highly-rated Plex titles. Watched titles and higher ratings weigh more.
 func (r *Recommender) genreAffinity(ctx context.Context) (map[string]float64, error) {
 	raw := make(map[string]float64)
+	movieGenres := make(map[uint][]string)
+	tvGenres := make(map[uint][]string)
 
-	accumulate := func(genre string, rating float64, viewCount int) {
-		for _, g := range splitGenres(genre) {
+	accumulate := func(genres []string, rating float64, viewCount int) {
+		for _, g := range genres {
 			w := rating / 10.0
 			if viewCount > 0 {
 				w += 1.0
@@ -29,14 +31,38 @@ func (r *Recommender) genreAffinity(ctx context.Context) (map[string]float64, er
 		return nil, fmt.Errorf("affinity movies: %w", err)
 	}
 	for _, m := range movies {
-		accumulate(m.Genre, m.Rating, m.ViewCount)
+		g := splitGenres(m.Genre)
+		movieGenres[m.ID] = g
+		accumulate(g, m.Rating, m.ViewCount)
 	}
 	var shows []models.TVShow
 	if err := r.db.WithContext(ctx).Find(&shows).Error; err != nil {
 		return nil, fmt.Errorf("affinity shows: %w", err)
 	}
 	for _, s := range shows {
-		accumulate(s.Genre, s.Rating, s.ViewCount)
+		g := splitGenres(s.Genre)
+		tvGenres[s.ID] = g
+		accumulate(g, s.Rating, s.ViewCount)
+	}
+
+	// Fold in external rated/score signals: a high signal lifts its title's genres.
+	var sigs []models.ExternalSignal
+	if err := r.db.WithContext(ctx).
+		Where("kind IN ?", []string{models.SignalKindRated, models.SignalKindScore}).
+		Find(&sigs).Error; err != nil {
+		return nil, fmt.Errorf("affinity signals: %w", err)
+	}
+	for _, sig := range sigs {
+		var genres []string
+		switch {
+		case sig.MovieID != nil:
+			genres = movieGenres[*sig.MovieID]
+		case sig.TVShowID != nil:
+			genres = tvGenres[*sig.TVShowID]
+		}
+		for _, g := range genres {
+			raw[g] += sig.Value / 10.0
+		}
 	}
 
 	peak := 0.0

--- a/lib/recommend/profile_test.go
+++ b/lib/recommend/profile_test.go
@@ -2,6 +2,7 @@ package recommend
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"github.com/icco/recommender/models"
@@ -60,5 +61,22 @@ func TestGenreAffinity_blendsRatedSignals(t *testing.T) {
 	}
 	if aff["Comedy"] <= aff["Horror"] {
 		t.Errorf("rated signal should lift Comedy (%.2f) above Horror (%.2f)", aff["Comedy"], aff["Horror"])
+	}
+}
+
+func TestLovedTitles_listsHighlyRated(t *testing.T) {
+	db := testDB(t)
+	r := testRecommender(db)
+	ctx := context.Background()
+	m := models.Movie{Title: "Loved Film", Year: 2000, PlexRatingKey: "a"}
+	db.Create(&m)
+	db.Create(&models.ExternalSignal{Source: models.SourceTrakt, ExternalRef: "rated:1", Kind: models.SignalKindRated, MovieID: &m.ID, Value: 10})
+
+	s, err := r.lovedTitles(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(s, "Loved Film") {
+		t.Errorf("expected loved summary to include the title, got %q", s)
 	}
 }

--- a/lib/recommend/profile_test.go
+++ b/lib/recommend/profile_test.go
@@ -42,3 +42,23 @@ func TestTasteProfile_nonEmptyWhenSignalsExist(t *testing.T) {
 		t.Error("expected a non-empty profile when watched titles exist")
 	}
 }
+
+func TestGenreAffinity_blendsRatedSignals(t *testing.T) {
+	db := testDB(t)
+	r := testRecommender(db)
+	ctx := context.Background()
+
+	comedy := models.Movie{Title: "C", Genre: "Comedy", Rating: 0, ViewCount: 0, PlexRatingKey: "a"}
+	horror := models.Movie{Title: "H", Genre: "Horror", Rating: 0, ViewCount: 0, PlexRatingKey: "b"}
+	db.Create(&comedy)
+	db.Create(&horror)
+	db.Create(&models.ExternalSignal{Source: models.SourceTrakt, ExternalRef: "rated:1", Kind: models.SignalKindRated, MovieID: &comedy.ID, Value: 10})
+
+	aff, err := r.genreAffinity(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if aff["Comedy"] <= aff["Horror"] {
+		t.Errorf("rated signal should lift Comedy (%.2f) above Horror (%.2f)", aff["Comedy"], aff["Horror"])
+	}
+}

--- a/lib/recommend/prompts/recommendation.txt
+++ b/lib/recommend/prompts/recommendation.txt
@@ -10,6 +10,7 @@ Rules:
 
 {{if .Profile}}User taste profile:
 {{.Profile}}
+{{end}}{{if .Loved}}{{.Loved}}
 {{end}}
 Movie shortlist:
 {{.Movies}}

--- a/lib/recommend/recommend.go
+++ b/lib/recommend/recommend.go
@@ -35,22 +35,24 @@ type StatsData struct {
 // Recommender produces and serves daily Plex/TMDb recommendations using
 // Gemini. Loggers are taken from per-call ctx via gutil/logging.
 type Recommender struct {
-	db    *gorm.DB
-	plex  *plex.Client
-	tmdb  *tmdb.Client
-	chat  Chatter
-	model string
+	db     *gorm.DB
+	plex   *plex.Client
+	tmdb   *tmdb.Client
+	chat   Chatter
+	model  string
+	sigCfg SignalConfig
 }
 
 // New creates a new Recommender instance with the provided dependencies.
 // Loggers are sourced from per-call ctx via gutil/logging.
-func New(db *gorm.DB, plexClient *plex.Client, tmdbClient *tmdb.Client, chat Chatter, model string) (*Recommender, error) {
+func New(db *gorm.DB, plexClient *plex.Client, tmdbClient *tmdb.Client, chat Chatter, model string, sigCfg SignalConfig) (*Recommender, error) {
 	return &Recommender{
-		db:    db,
-		plex:  plexClient,
-		tmdb:  tmdbClient,
-		chat:  chat,
-		model: model,
+		db:     db,
+		plex:   plexClient,
+		tmdb:   tmdbClient,
+		chat:   chat,
+		model:  model,
+		sigCfg: sigCfg,
 	}, nil
 }
 

--- a/lib/recommend/recommend_test.go
+++ b/lib/recommend/recommend_test.go
@@ -29,7 +29,7 @@ func testDB(t *testing.T) *gorm.DB {
 	})
 	if err := db.AutoMigrate(
 		&models.Recommendation{}, &models.Movie{}, &models.TVShow{},
-		&models.GenerationRun{}, &models.ExternalSignal{},
+		&models.GenerationRun{}, &models.ExternalSignal{}, &models.OAuthToken{},
 	); err != nil {
 		t.Fatal(err)
 	}

--- a/lib/recommend/signals.go
+++ b/lib/recommend/signals.go
@@ -1,0 +1,188 @@
+package recommend
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strconv"
+	"time"
+
+	"github.com/icco/gutil/logging"
+	"github.com/icco/recommender/lib/trakt"
+	"github.com/icco/recommender/models"
+	"go.uber.org/zap"
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+)
+
+// SignalSource fetches external data and upserts ExternalSignal rows joined to
+// owned Plex titles. Name is the models.Source* value it writes.
+type SignalSource interface {
+	Name() string
+	Sync(ctx context.Context) (int, error)
+}
+
+// upsertSignal inserts or updates a signal on its (source, external_ref, kind) key.
+func upsertSignal(ctx context.Context, db *gorm.DB, sig models.ExternalSignal) error {
+	sig.UpdatedAt = time.Now()
+	return db.WithContext(ctx).Clauses(clause.OnConflict{
+		Columns:   []clause.Column{{Name: "source"}, {Name: "external_ref"}, {Name: "kind"}},
+		DoUpdates: clause.AssignmentColumns([]string{"value", "movie_id", "tv_show_id", "updated_at"}),
+	}).Create(&sig).Error
+}
+
+// matchPlexID resolves external identifiers to an owned Plex movie or TV show,
+// preferring TMDb, then IMDb, then TVDb. Returns (nil, nil) if not owned.
+func matchPlexID(ctx context.Context, db *gorm.DB, tmdb *int, imdb, tvdb string, isShow bool) (movieID, tvID *uint) {
+	lookup := func(column string, value any) *uint {
+		if isShow {
+			var s models.TVShow
+			if err := db.WithContext(ctx).Where(column+" = ?", value).First(&s).Error; err == nil {
+				return &s.ID
+			}
+			return nil
+		}
+		var m models.Movie
+		if err := db.WithContext(ctx).Where(column+" = ?", value).First(&m).Error; err == nil {
+			return &m.ID
+		}
+		return nil
+	}
+
+	var id *uint
+	if tmdb != nil && *tmdb > 0 {
+		id = lookup("tm_db_id", *tmdb)
+	}
+	if id == nil && imdb != "" {
+		id = lookup("im_db_id", imdb)
+	}
+	if id == nil && tvdb != "" {
+		id = lookup("tv_db_id", tvdb)
+	}
+	if id == nil {
+		return nil, nil
+	}
+	if isShow {
+		return nil, id
+	}
+	return id, nil
+}
+
+// traktSource syncs Trakt watched/ratings/watchlist into ExternalSignal rows.
+type traktSource struct {
+	db     *gorm.DB
+	client *trakt.Client
+}
+
+func (s *traktSource) Name() string { return models.SourceTrakt }
+
+// syncPath maps a Trakt sync endpoint to the signal kind it produces.
+type syncPath struct {
+	path string
+	kind string
+}
+
+var traktPaths = []syncPath{
+	{"sync/watched/movies", models.SignalKindWatched},
+	{"sync/watched/shows", models.SignalKindWatched},
+	{"sync/ratings/movies", models.SignalKindRated},
+	{"sync/ratings/shows", models.SignalKindRated},
+	{"sync/watchlist/movies", models.SignalKindWatchlist},
+	{"sync/watchlist/shows", models.SignalKindWatchlist},
+}
+
+// Sync fetches all Trakt sync endpoints, joins to owned Plex titles, and upserts
+// signals. A valid access token is required (see accessToken).
+func (s *traktSource) Sync(ctx context.Context) (int, error) {
+	l := logging.FromContext(ctx)
+	token, err := s.accessToken(ctx)
+	if err != nil {
+		return 0, err
+	}
+	count := 0
+	for _, sp := range traktPaths {
+		rows, err := s.client.Sync(ctx, token, sp.path)
+		if err != nil {
+			l.Warnw("trakt sync path failed", "path", sp.path, zap.Error(err))
+			continue
+		}
+		for _, row := range rows {
+			media := row.Movie
+			isShow := false
+			if media == nil {
+				media = row.Show
+				isShow = true
+			}
+			if media == nil {
+				continue
+			}
+			movieID, tvID := matchPlexID(ctx, s.db, nilIfZero(media.IDs.TMDb), media.IDs.IMDb, itoaOrEmpty(media.IDs.TVDb), isShow)
+			if movieID == nil && tvID == nil {
+				continue // not owned
+			}
+			value := 1.0
+			if sp.kind == models.SignalKindRated {
+				value = float64(row.Rating)
+			}
+			ref := fmt.Sprintf("%s:%d", sp.kind, media.IDs.Trakt)
+			if err := upsertSignal(ctx, s.db, models.ExternalSignal{
+				Source: models.SourceTrakt, ExternalRef: ref, Kind: sp.kind,
+				MovieID: movieID, TVShowID: tvID, Value: value,
+			}); err != nil {
+				l.Warnw("upsert trakt signal failed", "ref", ref, zap.Error(err))
+				continue
+			}
+			count++
+		}
+	}
+	return count, nil
+}
+
+// accessToken returns a valid Trakt access token, refreshing if expired.
+func (s *traktSource) accessToken(ctx context.Context) (string, error) {
+	var tok models.OAuthToken
+	err := s.db.WithContext(ctx).Where("source = ?", models.SourceTrakt).First(&tok).Error
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		return "", fmt.Errorf("trakt not connected; visit /trakt/connect")
+	}
+	if err != nil {
+		return "", fmt.Errorf("load trakt token: %w", err)
+	}
+	if time.Now().Before(tok.ExpiresAt.Add(-1 * time.Minute)) {
+		return tok.AccessToken, nil
+	}
+	refreshed, err := s.client.RefreshToken(ctx, tok.RefreshToken)
+	if err != nil {
+		return "", fmt.Errorf("refresh trakt token: %w", err)
+	}
+	if err := s.saveToken(ctx, refreshed); err != nil {
+		return "", err
+	}
+	return refreshed.AccessToken, nil
+}
+
+// saveToken upserts the Trakt token row.
+func (s *traktSource) saveToken(ctx context.Context, tok *trakt.Token) error {
+	row := models.OAuthToken{
+		Source: models.SourceTrakt, AccessToken: tok.AccessToken,
+		RefreshToken: tok.RefreshToken, ExpiresAt: tok.ExpiresAt(), UpdatedAt: time.Now(),
+	}
+	return s.db.WithContext(ctx).Clauses(clause.OnConflict{
+		Columns:   []clause.Column{{Name: "source"}},
+		DoUpdates: clause.AssignmentColumns([]string{"access_token", "refresh_token", "expires_at", "updated_at"}),
+	}).Create(&row).Error
+}
+
+func nilIfZero(n int) *int {
+	if n == 0 {
+		return nil
+	}
+	return &n
+}
+
+func itoaOrEmpty(n int) string {
+	if n == 0 {
+		return ""
+	}
+	return strconv.Itoa(n)
+}

--- a/lib/recommend/signals.go
+++ b/lib/recommend/signals.go
@@ -280,3 +280,52 @@ func (r *Recommender) SyncSignals(ctx context.Context) {
 		l.Infow("signal source synced", "source", src.Name(), "count", n)
 	}
 }
+
+// storeTraktToken persists a Trakt token set.
+func (r *Recommender) storeTraktToken(ctx context.Context, tok *trakt.Token) error {
+	return (&traktSource{db: r.db}).saveToken(ctx, tok)
+}
+
+// TraktConnect starts the OAuth device flow and returns the user code + URL to
+// visit. A background goroutine polls until authorized and stores the token.
+func (r *Recommender) TraktConnect(ctx context.Context) (userCode, verificationURL string, err error) {
+	client := r.traktClient()
+	if client == nil {
+		return "", "", fmt.Errorf("trakt not configured (set TRAKT_CLIENT_ID/SECRET)")
+	}
+	dc, err := client.RequestDeviceCode(ctx)
+	if err != nil {
+		return "", "", fmt.Errorf("request device code: %w", err)
+	}
+	interval := time.Duration(dc.Interval) * time.Second
+	if interval <= 0 {
+		interval = 5 * time.Second
+	}
+	deadline := time.Now().Add(time.Duration(dc.ExpiresIn) * time.Second)
+
+	//nolint:contextcheck // background poll must outlive the request
+	go func() {
+		bg := logging.NewContext(context.Background(), logging.FromContext(ctx))
+		l := logging.FromContext(bg)
+		for time.Now().Before(deadline) {
+			time.Sleep(interval)
+			tok, perr := client.PollForToken(bg, dc.DeviceCode)
+			if perr != nil {
+				l.Warnw("trakt poll failed", zap.Error(perr))
+				return
+			}
+			if tok == nil {
+				continue // pending
+			}
+			if serr := r.storeTraktToken(bg, tok); serr != nil {
+				l.Errorw("store trakt token failed", zap.Error(serr))
+				return
+			}
+			l.Infow("trakt connected; token stored")
+			return
+		}
+		l.Warnw("trakt device code expired before authorization")
+	}()
+
+	return dc.UserCode, dc.VerificationURL, nil
+}

--- a/lib/recommend/signals.go
+++ b/lib/recommend/signals.go
@@ -303,7 +303,7 @@ func (r *Recommender) TraktConnect(ctx context.Context) (userCode, verificationU
 	}
 	deadline := time.Now().Add(time.Duration(dc.ExpiresIn) * time.Second)
 
-	//nolint:contextcheck // background poll must outlive the request
+	//nolint:contextcheck,gosec // background poll must outlive the request, so it deliberately uses a detached context
 	go func() {
 		bg := logging.NewContext(context.Background(), logging.FromContext(ctx))
 		l := logging.FromContext(bg)

--- a/lib/recommend/signals.go
+++ b/lib/recommend/signals.go
@@ -5,9 +5,11 @@ import (
 	"errors"
 	"fmt"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/icco/gutil/logging"
+	"github.com/icco/recommender/lib/anilist"
 	"github.com/icco/recommender/lib/trakt"
 	"github.com/icco/recommender/models"
 	"go.uber.org/zap"
@@ -185,4 +187,55 @@ func itoaOrEmpty(n int) string {
 		return ""
 	}
 	return strconv.Itoa(n)
+}
+
+// anilistSource syncs a user's AniList anime scores, matched to owned Plex titles
+// by title + year.
+type anilistSource struct {
+	db       *gorm.DB
+	client   *anilist.Client
+	username string
+}
+
+func (s *anilistSource) Name() string { return models.SourceAniList }
+
+// Sync fetches the AniList list and upserts score signals for titles owned in Plex.
+func (s *anilistSource) Sync(ctx context.Context) (int, error) {
+	l := logging.FromContext(ctx)
+	entries, err := s.client.List(ctx, s.username)
+	if err != nil {
+		return 0, fmt.Errorf("anilist list: %w", err)
+	}
+	count := 0
+	for _, e := range entries {
+		movieID, tvID := matchByTitleYear(ctx, s.db, e.Title, e.Year)
+		if movieID == nil && tvID == nil {
+			continue
+		}
+		ref := fmt.Sprintf("score:%s:%d", strings.ToLower(e.Title), e.Year)
+		if err := upsertSignal(ctx, s.db, models.ExternalSignal{
+			Source: models.SourceAniList, ExternalRef: ref, Kind: models.SignalKindScore,
+			MovieID: movieID, TVShowID: tvID, Value: e.Score,
+		}); err != nil {
+			l.Warnw("upsert anilist signal failed", "ref", ref, zap.Error(err))
+			continue
+		}
+		count++
+	}
+	l.Infow("anilist sync", "entries", len(entries), "matched", count)
+	return count, nil
+}
+
+// matchByTitleYear finds an owned Plex title by case-insensitive title + year,
+// checking TV shows first (anime are usually series), then movies.
+func matchByTitleYear(ctx context.Context, db *gorm.DB, title string, year int) (movieID, tvID *uint) {
+	var show models.TVShow
+	if err := db.WithContext(ctx).Where("title = ? COLLATE NOCASE AND year = ?", title, year).First(&show).Error; err == nil {
+		return nil, &show.ID
+	}
+	var movie models.Movie
+	if err := db.WithContext(ctx).Where("title = ? COLLATE NOCASE AND year = ?", title, year).First(&movie).Error; err == nil {
+		return &movie.ID, nil
+	}
+	return nil, nil
 }

--- a/lib/recommend/signals.go
+++ b/lib/recommend/signals.go
@@ -239,3 +239,44 @@ func matchByTitleYear(ctx context.Context, db *gorm.DB, title string, year int) 
 	}
 	return nil, nil
 }
+
+// SignalConfig holds credentials/usernames for external signal sources. Empty
+// fields disable that source.
+type SignalConfig struct {
+	TraktClientID     string
+	TraktClientSecret string
+	AniListUsername   string
+}
+
+// traktClient returns a Trakt client if credentials are configured, else nil.
+func (r *Recommender) traktClient() *trakt.Client {
+	if r.sigCfg.TraktClientID == "" || r.sigCfg.TraktClientSecret == "" {
+		return nil
+	}
+	return trakt.NewClient(r.sigCfg.TraktClientID, r.sigCfg.TraktClientSecret)
+}
+
+// configuredSources returns the enabled signal sources.
+func (r *Recommender) configuredSources() []SignalSource {
+	var out []SignalSource
+	if c := r.traktClient(); c != nil {
+		out = append(out, &traktSource{db: r.db, client: c})
+	}
+	if r.sigCfg.AniListUsername != "" {
+		out = append(out, &anilistSource{db: r.db, client: anilist.NewClient(), username: r.sigCfg.AniListUsername})
+	}
+	return out
+}
+
+// SyncSignals runs every configured source best-effort; failures are logged.
+func (r *Recommender) SyncSignals(ctx context.Context) {
+	l := logging.FromContext(ctx)
+	for _, src := range r.configuredSources() {
+		n, err := src.Sync(ctx)
+		if err != nil {
+			l.Warnw("signal source sync failed", "source", src.Name(), zap.Error(err))
+			continue
+		}
+		l.Infow("signal source synced", "source", src.Name(), "count", n)
+	}
+}

--- a/lib/recommend/signals_test.go
+++ b/lib/recommend/signals_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/icco/recommender/lib/anilist"
 	"github.com/icco/recommender/lib/trakt"
 	"github.com/icco/recommender/models"
 )
@@ -52,5 +53,38 @@ func TestTraktSource_Sync_joinsAndUpserts(t *testing.T) {
 	// Only the tmdb=603 movie is owned; the 999999 one is dropped.
 	if len(sigs) != 1 || sigs[0].MovieID == nil || sigs[0].Value != 10 {
 		t.Fatalf("bad signals: %+v", sigs)
+	}
+}
+
+func TestAniListSource_Sync_matchesByTitleYear(t *testing.T) {
+	db := testDB(t)
+	ctx := context.Background()
+	if err := db.Create(&models.TVShow{Title: "Demon Slayer", Year: 2019, PlexRatingKey: "s1"}).Error; err != nil {
+		t.Fatal(err)
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"data":{"User":{"mediaListOptions":{"scoreFormat":"POINT_10"}},
+			"MediaListCollection":{"lists":[{"entries":[
+				{"score":9,"media":{"seasonYear":2019,"title":{"romaji":"Kimetsu","english":"Demon Slayer"}}},
+				{"score":9,"media":{"seasonYear":1990,"title":{"romaji":"Nope","english":"Not Owned"}}}
+			]}]}}}`))
+	}))
+	defer srv.Close()
+
+	c := anilist.NewClient()
+	c.URL = srv.URL
+	s := &anilistSource{db: db, client: c, username: "nat"}
+	n, err := s.Sync(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n != 1 {
+		t.Fatalf("expected 1 matched signal, got %d", n)
+	}
+	var sigs []models.ExternalSignal
+	db.Where("source = ?", models.SourceAniList).Find(&sigs)
+	if len(sigs) != 1 || sigs[0].TVShowID == nil || sigs[0].Value != 9 {
+		t.Fatalf("bad anilist signals: %+v", sigs)
 	}
 }

--- a/lib/recommend/signals_test.go
+++ b/lib/recommend/signals_test.go
@@ -88,3 +88,19 @@ func TestAniListSource_Sync_matchesByTitleYear(t *testing.T) {
 		t.Fatalf("bad anilist signals: %+v", sigs)
 	}
 }
+
+func TestStoreTraktToken_upserts(t *testing.T) {
+	db := testDB(t)
+	r := &Recommender{db: db, sigCfg: SignalConfig{TraktClientID: "a", TraktClientSecret: "b"}}
+	ctx := context.Background()
+	if err := r.storeTraktToken(ctx, &trakt.Token{AccessToken: "x", RefreshToken: "y", ExpiresIn: 3600, CreatedAt: 1700000000}); err != nil {
+		t.Fatal(err)
+	}
+	var tok models.OAuthToken
+	if err := db.Where("source = ?", models.SourceTrakt).First(&tok).Error; err != nil {
+		t.Fatal(err)
+	}
+	if tok.AccessToken != "x" {
+		t.Fatalf("bad token: %+v", tok)
+	}
+}

--- a/lib/recommend/signals_test.go
+++ b/lib/recommend/signals_test.go
@@ -63,7 +63,7 @@ func TestAniListSource_Sync_matchesByTitleYear(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		_, _ = w.Write([]byte(`{"data":{"User":{"mediaListOptions":{"scoreFormat":"POINT_10"}},
 			"MediaListCollection":{"lists":[{"entries":[
 				{"score":9,"media":{"seasonYear":2019,"title":{"romaji":"Kimetsu","english":"Demon Slayer"}}},

--- a/lib/recommend/signals_test.go
+++ b/lib/recommend/signals_test.go
@@ -1,0 +1,56 @@
+package recommend
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/icco/recommender/lib/trakt"
+	"github.com/icco/recommender/models"
+)
+
+func TestTraktSource_Sync_joinsAndUpserts(t *testing.T) {
+	db := testDB(t)
+	ctx := context.Background()
+
+	tmdb603 := 603
+	if err := db.Create(&models.Movie{Title: "The Matrix", Year: 1999, TMDbID: &tmdb603, PlexRatingKey: "m1"}).Error; err != nil {
+		t.Fatal(err)
+	}
+	// Seed a valid, non-expired token so Sync skips refresh.
+	if err := db.Create(&models.OAuthToken{Source: models.SourceTrakt, AccessToken: "tok", RefreshToken: "r", ExpiresAt: time.Now().Add(time.Hour)}).Error; err != nil {
+		t.Fatal(err)
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/sync/ratings/movies":
+			_, _ = w.Write([]byte(`[{"rating":10,"movie":{"ids":{"tmdb":603}}},{"rating":8,"movie":{"ids":{"tmdb":999999}}}]`))
+		default:
+			_, _ = w.Write([]byte(`[]`))
+		}
+	}))
+	defer srv.Close()
+
+	c := trakt.NewClient("cid", "secret")
+	c.BaseURL = srv.URL
+	s := &traktSource{db: db, client: c}
+
+	n, err := s.Sync(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n == 0 {
+		t.Fatal("expected some signals synced")
+	}
+	var sigs []models.ExternalSignal
+	if err := db.Where("source = ? AND kind = ?", models.SourceTrakt, models.SignalKindRated).Find(&sigs).Error; err != nil {
+		t.Fatal(err)
+	}
+	// Only the tmdb=603 movie is owned; the 999999 one is dropped.
+	if len(sigs) != 1 || sigs[0].MovieID == nil || sigs[0].Value != 10 {
+		t.Fatalf("bad signals: %+v", sigs)
+	}
+}

--- a/lib/trakt/client.go
+++ b/lib/trakt/client.go
@@ -1,0 +1,178 @@
+// Package trakt is a minimal Trakt API client: OAuth device flow, token
+// refresh, and the sync endpoints the recommender uses as ranking signals.
+package trakt
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+)
+
+const (
+	defaultBaseURL = "https://api.trakt.tv"
+	apiVersion     = "2"
+)
+
+// Client talks to the Trakt API. BaseURL is overridable for tests.
+type Client struct {
+	clientID     string
+	clientSecret string
+	BaseURL      string
+	httpClient   *http.Client
+}
+
+// NewClient returns a Trakt client for the given API app credentials.
+func NewClient(clientID, clientSecret string) *Client {
+	return &Client{
+		clientID:     clientID,
+		clientSecret: clientSecret,
+		BaseURL:      defaultBaseURL,
+		httpClient:   &http.Client{Timeout: 30 * time.Second},
+	}
+}
+
+// IDs holds the external identifiers Trakt returns for a title.
+type IDs struct {
+	Trakt int    `json:"trakt"`
+	IMDb  string `json:"imdb"`
+	TMDb  int    `json:"tmdb"`
+	TVDb  int    `json:"tvdb"`
+}
+
+// Media is a movie or show entry within a sync row.
+type Media struct {
+	Title string `json:"title"`
+	Year  int    `json:"year"`
+	IDs   IDs    `json:"ids"`
+}
+
+// SyncRow is one item from a sync/* endpoint. Exactly one of Movie/Show is set;
+// Rating is populated for ratings endpoints.
+type SyncRow struct {
+	Rating int    `json:"rating"`
+	Movie  *Media `json:"movie"`
+	Show   *Media `json:"show"`
+}
+
+// DeviceCode is the response from the device-code endpoint.
+type DeviceCode struct {
+	DeviceCode      string `json:"device_code"`
+	UserCode        string `json:"user_code"`
+	VerificationURL string `json:"verification_url"`
+	ExpiresIn       int    `json:"expires_in"`
+	Interval        int    `json:"interval"`
+}
+
+// Token is an OAuth token set.
+type Token struct {
+	AccessToken  string `json:"access_token"`
+	RefreshToken string `json:"refresh_token"`
+	ExpiresIn    int    `json:"expires_in"`
+	CreatedAt    int64  `json:"created_at"`
+}
+
+// ExpiresAt is when the access token expires.
+func (t Token) ExpiresAt() time.Time {
+	return time.Unix(t.CreatedAt, 0).Add(time.Duration(t.ExpiresIn) * time.Second)
+}
+
+func (c *Client) postJSON(ctx context.Context, path string, body, out any) (int, error) {
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return 0, fmt.Errorf("marshal body: %w", err)
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.BaseURL+"/"+path, bytes.NewReader(buf))
+	if err != nil {
+		return 0, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return 0, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	data, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return resp.StatusCode, err
+	}
+	if resp.StatusCode >= 400 {
+		return resp.StatusCode, fmt.Errorf("trakt %s: HTTP %d: %s", path, resp.StatusCode, string(data))
+	}
+	if out != nil {
+		if err := json.Unmarshal(data, out); err != nil {
+			return resp.StatusCode, fmt.Errorf("decode %s: %w", path, err)
+		}
+	}
+	return resp.StatusCode, nil
+}
+
+// RequestDeviceCode starts the OAuth device flow.
+func (c *Client) RequestDeviceCode(ctx context.Context) (*DeviceCode, error) {
+	var dc DeviceCode
+	if _, err := c.postJSON(ctx, "oauth/device/code", map[string]string{"client_id": c.clientID}, &dc); err != nil {
+		return nil, err
+	}
+	return &dc, nil
+}
+
+// PollForToken polls once for the token; HTTP 400 means "authorization pending".
+// Returns (nil, nil) when still pending so the caller can wait and retry.
+func (c *Client) PollForToken(ctx context.Context, deviceCode string) (*Token, error) {
+	var tok Token
+	status, err := c.postJSON(ctx, "oauth/device/token", map[string]string{
+		"code": deviceCode, "client_id": c.clientID, "client_secret": c.clientSecret,
+	}, &tok)
+	if status == http.StatusBadRequest {
+		return nil, nil // pending
+	}
+	if err != nil {
+		return nil, err
+	}
+	return &tok, nil
+}
+
+// RefreshToken exchanges a refresh token for a new token set.
+func (c *Client) RefreshToken(ctx context.Context, refreshToken string) (*Token, error) {
+	var tok Token
+	if _, err := c.postJSON(ctx, "oauth/token", map[string]string{
+		"refresh_token": refreshToken,
+		"client_id":     c.clientID,
+		"client_secret": c.clientSecret,
+		"grant_type":    "refresh_token",
+	}, &tok); err != nil {
+		return nil, err
+	}
+	return &tok, nil
+}
+
+// Sync GETs a sync/* endpoint (e.g. "sync/watched/movies") with the access token.
+func (c *Client) Sync(ctx context.Context, accessToken, path string) ([]SyncRow, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.BaseURL+"/"+path, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("trakt-api-version", apiVersion)
+	req.Header.Set("trakt-api-key", c.clientID)
+	req.Header.Set("Authorization", "Bearer "+accessToken)
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	data, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode >= 400 {
+		return nil, fmt.Errorf("trakt %s: HTTP %d: %s", path, resp.StatusCode, string(data))
+	}
+	var rows []SyncRow
+	if err := json.Unmarshal(data, &rows); err != nil {
+		return nil, fmt.Errorf("decode %s: %w", path, err)
+	}
+	return rows, nil
+}

--- a/lib/trakt/client_test.go
+++ b/lib/trakt/client_test.go
@@ -1,0 +1,45 @@
+package trakt
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestSync_parsesMoviesWithIDs(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("trakt-api-key") != "cid" || r.Header.Get("Authorization") != "Bearer tok" {
+			t.Errorf("missing auth headers: %v", r.Header)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`[{"rating":9,"movie":{"title":"The Matrix","year":1999,"ids":{"trakt":1,"imdb":"tt0133093","tmdb":603}}}]`))
+	}))
+	defer srv.Close()
+
+	c := NewClient("cid", "secret")
+	c.BaseURL = srv.URL
+	rows, err := c.Sync(context.Background(), "tok", "sync/ratings/movies")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(rows) != 1 || rows[0].Movie == nil || rows[0].Movie.IDs.TMDb != 603 || rows[0].Rating != 9 {
+		t.Fatalf("bad parse: %+v", rows)
+	}
+}
+
+func TestRequestDeviceCode(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"device_code":"dc","user_code":"1234","verification_url":"https://trakt.tv/activate","expires_in":600,"interval":5}`))
+	}))
+	defer srv.Close()
+	c := NewClient("cid", "secret")
+	c.BaseURL = srv.URL
+	dc, err := c.RequestDeviceCode(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if dc.UserCode != "1234" || dc.DeviceCode != "dc" {
+		t.Fatalf("bad device code: %+v", dc)
+	}
+}

--- a/lib/trakt/client_test.go
+++ b/lib/trakt/client_test.go
@@ -29,7 +29,7 @@ func TestSync_parsesMoviesWithIDs(t *testing.T) {
 }
 
 func TestRequestDeviceCode(t *testing.T) {
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		_, _ = w.Write([]byte(`{"device_code":"dc","user_code":"1234","verification_url":"https://trakt.tv/activate","expires_in":600,"interval":5}`))
 	}))
 	defer srv.Close()

--- a/main.go
+++ b/main.go
@@ -155,6 +155,7 @@ func main() {
 	r.Get("/dates", handlers.HandleDates(recommender))
 	r.Get("/cron/recommend", handlers.HandleCron(recommender, fileLock))
 	r.Get("/cron/cache", handlers.HandleCache(plexClient, recommender, fileLock))
+	r.Get("/trakt/connect", handlers.HandleTraktConnect(recommender))
 	r.Get("/stats", handlers.HandleStats(recommender))
 	r.Get("/health", health.Check(gormDB))
 	r.Method(http.MethodGet, "/metrics", promhttp.HandlerFor(registry, promhttp.HandlerOpts{}))

--- a/main.go
+++ b/main.go
@@ -155,7 +155,7 @@ func main() {
 	r.Get("/dates", handlers.HandleDates(recommender))
 	r.Get("/cron/recommend", handlers.HandleCron(recommender, fileLock))
 	r.Get("/cron/cache", handlers.HandleCache(plexClient, recommender, fileLock))
-	r.Get("/trakt/connect", handlers.HandleTraktConnect(recommender))
+	r.Get("/trakt/connect", handlers.HandleTraktConnect(recommender, os.Getenv("TRAKT_CONNECT_TOKEN")))
 	r.Get("/stats", handlers.HandleStats(recommender))
 	r.Get("/health", health.Check(gormDB))
 	r.Method(http.MethodGet, "/metrics", promhttp.HandlerFor(registry, promhttp.HandlerOpts{}))

--- a/main.go
+++ b/main.go
@@ -131,7 +131,13 @@ func main() {
 		log.Fatalw("Failed to create Gemini client", zap.Error(err))
 	}
 
-	recommender, err := recommend.New(gormDB, plexClient, tmdbClient, chat, geminiModel)
+	sigCfg := recommend.SignalConfig{
+		TraktClientID:     os.Getenv("TRAKT_CLIENT_ID"),
+		TraktClientSecret: os.Getenv("TRAKT_CLIENT_SECRET"),
+		AniListUsername:   os.Getenv("ANILIST_USERNAME"),
+	}
+
+	recommender, err := recommend.New(gormDB, plexClient, tmdbClient, chat, geminiModel, sigCfg)
 	if err != nil {
 		log.Fatalw("Failed to create recommender", zap.Error(err))
 	}
@@ -148,7 +154,7 @@ func main() {
 	r.Get("/date/{date}", handlers.HandleDate(recommender))
 	r.Get("/dates", handlers.HandleDates(recommender))
 	r.Get("/cron/recommend", handlers.HandleCron(recommender, fileLock))
-	r.Get("/cron/cache", handlers.HandleCache(plexClient, fileLock))
+	r.Get("/cron/cache", handlers.HandleCache(plexClient, recommender, fileLock))
 	r.Get("/stats", handlers.HandleStats(recommender))
 	r.Get("/health", health.Check(gormDB))
 	r.Method(http.MethodGet, "/metrics", promhttp.HandlerFor(registry, promhttp.HandlerOpts{}))

--- a/models/models.go
+++ b/models/models.go
@@ -90,6 +90,8 @@ const (
 // Signal source + kind values for ExternalSignal.
 const (
 	SourcePlex          = "plex"
+	SourceTrakt         = "trakt"
+	SourceAniList       = "anilist"
 	SignalKindWatched   = "watched"
 	SignalKindRated     = "rated"
 	SignalKindScore     = "score"
@@ -120,4 +122,14 @@ type ExternalSignal struct {
 	TVShowID    *uint   `gorm:"index"`
 	Value       float64 `gorm:"default:0"`
 	UpdatedAt   time.Time
+}
+
+// OAuthToken stores an OAuth token set for an external source (e.g. Trakt).
+type OAuthToken struct {
+	ID           uint   `gorm:"primarykey"`
+	Source       string `gorm:"type:varchar(32);not null;uniqueIndex:idx_oauth_source"`
+	AccessToken  string `gorm:"type:varchar(512)"`
+	RefreshToken string `gorm:"type:varchar(512)"`
+	ExpiresAt    time.Time
+	UpdatedAt    time.Time
 }

--- a/template.env
+++ b/template.env
@@ -21,3 +21,10 @@ PORT=8080
 
 # Optional: Debug logging (true/false)
 DEBUG=false
+
+# Optional signal sources (leave blank to disable)
+TRAKT_CLIENT_ID=
+TRAKT_CLIENT_SECRET=
+# Shared secret to enable GET /trakt/connect (?token=...); disabled when blank
+TRAKT_CONNECT_TOKEN=
+ANILIST_USERNAME=


### PR DESCRIPTION
Adds Trakt and AniList as **ranking signals** over the Plex library — they re-rank titles you already own, never add new ones. Both optional (off unless configured). Roadmap Phases 3+4.

## What changed
- **Clients:** `lib/trakt` (device flow, token refresh, sync endpoints), `lib/anilist` (public GraphQL, score normalization).
- **Adapters** (`lib/recommend/signals.go`): fetch → join to owned Plex rows (Trakt by TMDb/IMDb/TVDb, AniList by title+year) → upsert `ExternalSignal`; unmatched dropped. Synced best-effort in `/cron/cache`.
- **Consumption:** genre-affinity blend, watchlist score boost, Trakt-watched treated as watched, "recently loved" prompt line.
- **Auth:** `GET /trakt/connect` device flow; tokens in a new `OAuthToken` table, auto-refreshed. Gated by `TRAKT_CONNECT_TOKEN` (disabled when unset) since it stores a credential.

## Config (all optional)
`TRAKT_CLIENT_ID`, `TRAKT_CLIENT_SECRET`, `TRAKT_CONNECT_TOKEN`, `ANILIST_USERNAME`.

## Testing
`go build`, `go test ./...`, `gofmt -l`, `go vet`, `golangci-lint` clean. Tests run offline (httptest + in-memory DB). Not run: live sync.