### PR TITLE
fix: tolerate string Guid field in Plex cache update

### DIFF
--- a/lib/plex/guid_test.go
+++ b/lib/plex/guid_test.go
@@ -1,10 +1,33 @@
 package plex
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/LukeHagar/plexgo/models/components"
 )
+
+func TestSectionMetadata_tolerantGuid(t *testing.T) {
+	// Array form (Plex with includeGuids=1): extract ids.
+	var arr sectionListMetadata
+	if err := json.Unmarshal([]byte(`{"ratingKey":"1","Guid":[{"id":"imdb://tt1"},{"id":"tmdb://2"}]}`), &arr); err != nil {
+		t.Fatalf("array guid: %v", err)
+	}
+	if got := sectionMetadataToPlexItem(arr).Guids; len(got) != 2 {
+		t.Errorf("array guids = %v, want 2", got)
+	}
+	// String form: Go's case-insensitive matching binds Plex's lowercase `guid`
+	// string to this field when the `Guid` array is absent. Must not error.
+	var str sectionListMetadata
+	if err := json.Unmarshal([]byte(`{"ratingKey":"2","Guid":"plex://movie/abc"}`), &str); err != nil {
+		t.Fatalf("string guid should not error: %v", err)
+	}
+	// Absent.
+	var none sectionListMetadata
+	if err := json.Unmarshal([]byte(`{"ratingKey":"3"}`), &none); err != nil {
+		t.Fatalf("absent guid: %v", err)
+	}
+}
 
 func TestParseGUIDs(t *testing.T) {
 	imdb, tmdb, tvdb := parseGUIDs([]string{

--- a/lib/plex/plexgo_convert.go
+++ b/lib/plex/plexgo_convert.go
@@ -66,11 +66,49 @@ type sectionListMetadata struct {
 	Genre     []struct {
 		Tag string `json:"tag"`
 	} `json:"Genre,omitempty"`
-	GUID []struct {
-		ID string `json:"id"`
-	} `json:"Guid,omitempty"`
-	LeafCount  *int `json:"leafCount,omitempty"`
-	ChildCount *int `json:"childCount,omitempty"`
+	GUID       plexGUIDs `json:"Guid,omitempty"`
+	LeafCount  *int      `json:"leafCount,omitempty"`
+	ChildCount *int      `json:"childCount,omitempty"`
+}
+
+// plexGUIDs decodes Plex's GUID field, which varies: an array of {id} objects
+// when includeGuids adds them, or (via Go's case-insensitive key matching) the
+// lowercase `guid` string when the array is absent. Both decode without error.
+type plexGUIDs []string
+
+func (g *plexGUIDs) UnmarshalJSON(b []byte) error {
+	b = bytes.TrimSpace(b)
+	if len(b) == 0 || string(b) == "null" {
+		*g = nil
+		return nil
+	}
+	switch b[0] {
+	case '[':
+		var arr []struct {
+			ID string `json:"id"`
+		}
+		if err := json.Unmarshal(b, &arr); err != nil {
+			return err
+		}
+		out := make(plexGUIDs, 0, len(arr))
+		for _, e := range arr {
+			if e.ID != "" {
+				out = append(out, e.ID)
+			}
+		}
+		*g = out
+	case '"':
+		var s string
+		if err := json.Unmarshal(b, &s); err != nil {
+			return err
+		}
+		if s != "" {
+			*g = plexGUIDs{s}
+		}
+	default:
+		*g = nil // unknown shape; ignore rather than fail the whole page
+	}
+	return nil
 }
 
 func sectionMetadataToPlexItem(md sectionListMetadata) Item {
@@ -88,12 +126,7 @@ func sectionMetadataToPlexItem(md sectionListMetadata) Item {
 	if md.Summary != nil {
 		summary = *md.Summary
 	}
-	var guids []string
-	for _, g := range md.GUID {
-		if g.ID != "" {
-			guids = append(guids, g.ID)
-		}
-	}
+	guids := []string(md.GUID)
 	return Item{
 		RatingKey:  rk,
 		Key:        md.Key,


### PR DESCRIPTION
The cache update has been failing in prod since the Phase-1 overhaul — every Plex library errors with `cannot unmarshal string into ...Metadata.Guid of type []struct{ID string}`, so 0 items are fetched and the cache never updates.

**Cause:** Plex returns `Guid` as an array of `{id}` only when `includeGuids` adds it. When absent, Go's case-insensitive JSON key matching binds Plex's lowercase `guid` **string** to the same struct field, which can't unmarshal into a slice.

**Fix:** a tolerant `plexGUIDs` type that decodes both the array and the string form (matching the existing `plexRatingKey` pattern). Regression test covers array/string/absent.

Recommendation generation was unaffected (it runs off already-cached rows), but GUIDs/multi-genre never populated — this unblocks that.