### PR TITLE
fix: cache Plex posters locally for the public page

### DIFF
--- a/handlers/handlers_test.go
+++ b/handlers/handlers_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestHandleTraktConnect_gate(t *testing.T) {
-	rec, err := recommend.New(nil, nil, nil, nil, "test", recommend.SignalConfig{})
+	rec, err := recommend.New(nil, nil, nil, nil, "test", recommend.SignalConfig{}, "")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/lib/plex/client.go
+++ b/lib/plex/client.go
@@ -9,6 +9,8 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"os"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -39,6 +41,37 @@ const (
 	// title columns on the Movie/TVShow tables.
 	titleKey = "title"
 )
+
+// DownloadImage fetches a Plex image URL (adding the auth token) and writes it to
+// dest, creating parent directories as needed. Used to cache posters locally so
+// the public web page doesn't need to reach the private Plex host.
+func (c *Client) DownloadImage(ctx context.Context, imageURL, dest string) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, imageURL, nil)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("X-Plex-Token", c.plexToken)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("fetch image: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("fetch image %s: HTTP %d", imageURL, resp.StatusCode)
+	}
+	if err := os.MkdirAll(filepath.Dir(dest), 0o750); err != nil {
+		return fmt.Errorf("create poster dir: %w", err)
+	}
+	f, err := os.Create(dest) //nolint:gosec // dest is server-controlled (poster dir + sanitized name)
+	if err != nil {
+		return fmt.Errorf("create poster file: %w", err)
+	}
+	defer func() { _ = f.Close() }()
+	if _, err := io.Copy(f, resp.Body); err != nil {
+		return fmt.Errorf("write poster: %w", err)
+	}
+	return nil
+}
 
 // NewClient creates a new Plex client with the provided configuration.
 // It initializes the Plex API client with the given URL and authentication token.

--- a/lib/recommend/generate.go
+++ b/lib/recommend/generate.go
@@ -4,13 +4,13 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"path/filepath"
 	"strings"
 	"text/template"
 	"time"
 
 	"github.com/icco/gutil/logging"
 	"github.com/icco/recommender/lib/recommend/prompts"
-	"github.com/icco/recommender/lib/tmdb"
 	"github.com/icco/recommender/models"
 	"go.uber.org/zap"
 	"gorm.io/gorm"
@@ -85,7 +85,7 @@ func (r *Recommender) GenerateRecommendations(ctx context.Context, date time.Tim
 
 	for i := range recs {
 		recs[i].Date = date
-		r.fillPoster(ctx, &recs[i])
+		r.cachePoster(ctx, &recs[i])
 	}
 
 	movieCount, tvCount := 0, 0
@@ -141,37 +141,32 @@ func (r *Recommender) renderPrompts(ctx context.Context, movies, tvshows []candi
 	return string(sysTmpl), b.String(), nil
 }
 
-// fillPoster lazily fetches a TMDb poster only when one is missing. Bounded to the
-// finalist set, so at most a handful of calls per run.
-func (r *Recommender) fillPoster(ctx context.Context, rec *models.Recommendation) {
-	if rec.PosterURL != "" || r.tmdb == nil {
+// cachePoster downloads the finalist's Plex poster into the local poster dir and
+// rewrites PosterURL to a public /posters/ path the web page can load. Plex thumb
+// URLs point at a private, token-gated host browsers can't reach. Bounded to the
+// finalist set, so at most a handful of downloads per run.
+func (r *Recommender) cachePoster(ctx context.Context, rec *models.Recommendation) {
+	if r.posterDir == "" || rec.PosterURL == "" || r.plex == nil {
 		return
 	}
-	l := logging.FromContext(ctx)
-	switch rec.Type {
-	case models.TypeMovie:
-		res, err := r.tmdb.SearchMovie(ctx, rec.Title, rec.Year)
-		if err != nil {
-			if !errors.Is(err, tmdb.ErrCircuitOpen) {
-				l.Warnw("poster fill (movie) failed", "title", rec.Title, zap.Error(err))
-			}
-			return
-		}
-		if len(res.Results) > 0 {
-			rec.PosterURL = r.tmdb.GetPosterURL(res.Results[0].PosterPath)
-		}
-	case models.TypeTVShow:
-		res, err := r.tmdb.SearchTVShow(ctx, rec.Title, rec.Year)
-		if err != nil {
-			if !errors.Is(err, tmdb.ErrCircuitOpen) {
-				l.Warnw("poster fill (tv) failed", "title", rec.Title, zap.Error(err))
-			}
-			return
-		}
-		if len(res.Results) > 0 {
-			rec.PosterURL = r.tmdb.GetPosterURL(res.Results[0].PosterPath)
-		}
+	name := fmt.Sprintf("%s-%d.jpg", rec.Type, posterID(rec))
+	dest := filepath.Join(r.posterDir, name)
+	if err := r.plex.DownloadImage(ctx, rec.PosterURL, dest); err != nil {
+		logging.FromContext(ctx).Warnw("cache poster failed", "title", rec.Title, zap.Error(err))
+		return
 	}
+	rec.PosterURL = "/posters/" + name
+}
+
+// posterID returns the Plex-backed ID used to name the cached poster file.
+func posterID(rec *models.Recommendation) uint {
+	switch {
+	case rec.MovieID != nil:
+		return *rec.MovieID
+	case rec.TVShowID != nil:
+		return *rec.TVShowID
+	}
+	return 0
 }
 
 func (r *Recommender) saveRecommendations(ctx context.Context, date time.Time, recs []models.Recommendation) error {

--- a/lib/recommend/recommend.go
+++ b/lib/recommend/recommend.go
@@ -35,24 +35,27 @@ type StatsData struct {
 // Recommender produces and serves daily Plex/TMDb recommendations using
 // Gemini. Loggers are taken from per-call ctx via gutil/logging.
 type Recommender struct {
-	db     *gorm.DB
-	plex   *plex.Client
-	tmdb   *tmdb.Client
-	chat   Chatter
-	model  string
-	sigCfg SignalConfig
+	db        *gorm.DB
+	plex      *plex.Client
+	tmdb      *tmdb.Client
+	chat      Chatter
+	model     string
+	sigCfg    SignalConfig
+	posterDir string
 }
 
 // New creates a new Recommender instance with the provided dependencies.
+// posterDir is where finalist posters are cached for public serving.
 // Loggers are sourced from per-call ctx via gutil/logging.
-func New(db *gorm.DB, plexClient *plex.Client, tmdbClient *tmdb.Client, chat Chatter, model string, sigCfg SignalConfig) (*Recommender, error) {
+func New(db *gorm.DB, plexClient *plex.Client, tmdbClient *tmdb.Client, chat Chatter, model string, sigCfg SignalConfig, posterDir string) (*Recommender, error) {
 	return &Recommender{
-		db:     db,
-		plex:   plexClient,
-		tmdb:   tmdbClient,
-		chat:   chat,
-		model:  model,
-		sigCfg: sigCfg,
+		db:        db,
+		plex:      plexClient,
+		tmdb:      tmdbClient,
+		chat:      chat,
+		model:     model,
+		sigCfg:    sigCfg,
+		posterDir: posterDir,
 	}, nil
 }
 

--- a/main.go
+++ b/main.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"path/filepath"
 	"strconv"
 	"syscall"
 	"time"
@@ -137,7 +138,13 @@ func main() {
 		AniListUsername:   os.Getenv("ANILIST_USERNAME"),
 	}
 
-	recommender, err := recommend.New(gormDB, plexClient, tmdbClient, chat, geminiModel, sigCfg)
+	// posterDir sits next to the DB in the data volume; DB_PATH is operator config.
+	posterDir := filepath.Join(filepath.Dir(dbPath), "posters")
+	if err := os.MkdirAll(posterDir, 0o750); err != nil { //nolint:gosec // posterDir derived from operator-set DB_PATH, not user input
+		log.Fatalw("Failed to create poster dir", zap.Error(err))
+	}
+
+	recommender, err := recommend.New(gormDB, plexClient, tmdbClient, chat, geminiModel, sigCfg, posterDir)
 	if err != nil {
 		log.Fatalw("Failed to create recommender", zap.Error(err))
 	}
@@ -149,6 +156,7 @@ func main() {
 	r.Use(middleware.Timeout(60 * time.Second))
 
 	r.Handle("/static/*", http.StripPrefix("/static/", http.FileServer(http.FS(static.Files))))
+	r.Handle("/posters/*", http.StripPrefix("/posters/", http.FileServer(http.Dir(posterDir))))
 
 	r.Get("/", handlers.HandleHome(recommender))
 	r.Get("/date/{date}", handlers.HandleDate(recommender))


### PR DESCRIPTION
Recommendation posters 404 on https://recommend.natwelch.com — they're stored as internal Plex thumb URLs (`http://192.168.1.54:32400/library/metadata/.../thumb/...`), a private, token-gated host browsers can't reach. (The pre-overhaul code happened to store public `image.tmdb.org` URLs via its per-title TMDb calls.)

**Fix:** at generation time, download each finalist's poster from Plex (the server already has the token and LAN access) into `/data/posters`, and rewrite `PosterURL` to a public `/posters/<type>-<id>.jpg` served by the recommender. Covers every title (not just TMDb-matched), and images persist in the data volume. Falls back silently if a download fails.

- `plex.Client.DownloadImage` fetches with the token → dest file.
- `/posters/*` served via `http.FileServer` from the poster dir (next to the DB).

Build/test/vet/golangci-lint clean. After deploy, today's row needs a regenerate to refresh its stored URLs.