### PR TITLE
fix: scope Plex token to Plex host, strip SQL log params, add secure headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,4 +133,4 @@ A day is "done" when a `GenerationRun` with status `ok` exists for it — tracke
 
 - **`/cron/cache`, `/cron/recommend`, and `/metrics` are unauthenticated.** The cron endpoints trigger paid Gemini calls and full Plex/Trakt/AniList syncs, so anyone who can reach them can drive cost and load. Restrict `/cron/*` and `/metrics` to trusted callers at the ingress/reverse proxy (source-IP allow-list or an internal-only route); the app does not gate them itself.
 - Cached-poster downloads only send the private `X-Plex-Token` to the configured Plex host, so an absolute thumb URL pointing off-host cannot exfiltrate the token or be used for SSRF with credentials.
-- SQL statements touching the OAuth token table are redacted before logging, so Trakt tokens never land in query traces.
+- The GORM logger strips bound parameter values from query traces (via `gorm.ParamsFilter`), so SQL is logged with placeholders and secrets like Trakt tokens never land in logs.

--- a/README.md
+++ b/README.md
@@ -128,3 +128,9 @@ The compose file runs a bundled `postgres:17` service (data in the `pgdata` volu
 2. **`/cron/recommend`** — Skips if a successful run already exists for the UTC day. Otherwise: loads cached titles (minus anything recommended in the last 30 days), scores them (rating + novelty + Plex-derived taste affinity), takes a date-seeded diverse shortlist, asks Gemini to pick the best fits **by ID** with a one-line reason, slots them deterministically (comedy / action-drama / rewatch / wildcard movies + unwatched TV), lazily fills any missing posters from TMDb, and **replaces** that day's rows in one transaction. Every attempt records a `GenerationRun`.
 
 A day is "done" when a `GenerationRun` with status `ok` exists for it — tracked explicitly rather than inferred from row counts, so cron never re-runs a completed day.
+
+## Security notes
+
+- **`/cron/cache`, `/cron/recommend`, and `/metrics` are unauthenticated.** The cron endpoints trigger paid Gemini calls and full Plex/Trakt/AniList syncs, so anyone who can reach them can drive cost and load. Restrict `/cron/*` and `/metrics` to trusted callers at the ingress/reverse proxy (source-IP allow-list or an internal-only route); the app does not gate them itself.
+- Cached-poster downloads only send the private `X-Plex-Token` to the configured Plex host, so an absolute thumb URL pointing off-host cannot exfiltrate the token or be used for SSRF with credentials.
+- SQL statements touching the OAuth token table are redacted before logging, so Trakt tokens never land in query traces.

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/go-chi/chi/v5 v5.3.0
 	github.com/icco/gutil v0.0.0-20260630032459-de9e83f7fbb2
 	github.com/prometheus/client_golang v1.23.2
+	github.com/unrolled/secure v1.17.0
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.69.0
 	go.opentelemetry.io/otel v1.44.0
 	go.opentelemetry.io/otel/exporters/prometheus v0.66.0

--- a/go.sum
+++ b/go.sum
@@ -75,6 +75,8 @@ github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UV
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
+github.com/unrolled/secure v1.17.0 h1:Io7ifFgo99Bnh0J7+Q+qcMzWM6kaDPCA5FroFZEdbWU=
+github.com/unrolled/secure v1.17.0/go.mod h1:BmF5hyM6tXczk3MpQkFf1hpKSRqCyhqcbiQtiAF7+40=
 go.opentelemetry.io/auto/sdk v1.2.1 h1:jXsnJ4Lmnqd11kwkBV2LgLoFMZKizbCi5fNZ/ipaZ64=
 go.opentelemetry.io/auto/sdk v1.2.1/go.mod h1:KRTj+aOaElaLi+wW1kO/DZRXwkF4C5xPbEe3ZiIhN7Y=
 go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.69.0 h1:8tvICD4vSTOOsNrsI4Ljf6C+6UKvpTEH5XY3JMoyPoo=

--- a/lib/db/logger.go
+++ b/lib/db/logger.go
@@ -20,8 +20,6 @@ type GormLogger struct {
 	logger *zap.SugaredLogger
 }
 
-// GormLogger implements gorm.ParamsFilter so bound parameters are stripped
-// before GORM interpolates them into traced SQL.
 var _ gorm.ParamsFilter = (*GormLogger)(nil)
 
 // NewGormLogger creates a new GORM logger that forwards to zap.
@@ -60,18 +58,13 @@ func (l *GormLogger) Error(ctx context.Context, msg string, data ...interface{})
 	l.loggerFor(ctx).Errorw(msg, "data", data)
 }
 
-// ParamsFilter drops bound parameter values from traced SQL. GORM calls this on
-// loggers that implement gorm.ParamsFilter, returning the SQL with placeholders
-// left un-interpolated ($1, $2, …). This keeps secrets (e.g. OAuth tokens) and
-// PII out of query logs — it is GORM's native ParameterizedQueries mechanism,
-// applied to this custom zap-backed logger.
+// ParamsFilter drops bound parameter values so GORM logs SQL with placeholders
+// left un-interpolated, keeping secrets (e.g. OAuth tokens) and PII out of logs.
 func (l *GormLogger) ParamsFilter(_ context.Context, sql string, _ ...any) (string, []any) {
 	return sql, nil
 }
 
 // Trace logs SQL query execution at debug level (or error level on failure).
-// Bound parameter values are stripped by ParamsFilter, so the logged SQL keeps
-// placeholders rather than interpolated values.
 func (l *GormLogger) Trace(ctx context.Context, begin time.Time, fc func() (sql string, rowsAffected int64), err error) {
 	elapsed := time.Since(begin)
 	sql, rows := fc()

--- a/lib/db/logger.go
+++ b/lib/db/logger.go
@@ -4,11 +4,11 @@ package db
 
 import (
 	"context"
-	"strings"
 	"time"
 
 	"github.com/icco/gutil/logging"
 	"go.uber.org/zap"
+	"gorm.io/gorm"
 	"gorm.io/gorm/logger"
 )
 
@@ -19,6 +19,10 @@ import (
 type GormLogger struct {
 	logger *zap.SugaredLogger
 }
+
+// GormLogger implements gorm.ParamsFilter so bound parameters are stripped
+// before GORM interpolates them into traced SQL.
+var _ gorm.ParamsFilter = (*GormLogger)(nil)
 
 // NewGormLogger creates a new GORM logger that forwards to zap.
 func NewGormLogger(base *zap.Logger) *GormLogger {
@@ -56,16 +60,21 @@ func (l *GormLogger) Error(ctx context.Context, msg string, data ...interface{})
 	l.loggerFor(ctx).Errorw(msg, "data", data)
 }
 
+// ParamsFilter drops bound parameter values from traced SQL. GORM calls this on
+// loggers that implement gorm.ParamsFilter, returning the SQL with placeholders
+// left un-interpolated ($1, $2, …). This keeps secrets (e.g. OAuth tokens) and
+// PII out of query logs — it is GORM's native ParameterizedQueries mechanism,
+// applied to this custom zap-backed logger.
+func (l *GormLogger) ParamsFilter(_ context.Context, sql string, _ ...any) (string, []any) {
+	return sql, nil
+}
+
 // Trace logs SQL query execution at debug level (or error level on failure).
-//
-// GORM renders trace SQL with parameter values already interpolated, so any
-// statement touching the OAuth token table would otherwise write live
-// access/refresh tokens into logs (at debug for every query, and at error on any
-// failed write regardless of log level). redactSQL scrubs those statements.
+// Bound parameter values are stripped by ParamsFilter, so the logged SQL keeps
+// placeholders rather than interpolated values.
 func (l *GormLogger) Trace(ctx context.Context, begin time.Time, fc func() (sql string, rowsAffected int64), err error) {
 	elapsed := time.Since(begin)
 	sql, rows := fc()
-	sql = redactSQL(sql)
 	scoped := l.loggerFor(ctx)
 
 	if err != nil {
@@ -83,14 +92,4 @@ func (l *GormLogger) Trace(ctx context.Context, begin time.Time, fc func() (sql 
 		"rows", rows,
 		"elapsed", elapsed,
 	)
-}
-
-// redactSQL replaces statements that touch credential-bearing tables with a
-// placeholder so interpolated secrets never reach the logs.
-func redactSQL(sql string) string {
-	// GORM maps the OAuthToken model to the "o_auth_tokens" table.
-	if strings.Contains(strings.ToLower(sql), "o_auth_tokens") {
-		return "[redacted: statement touches o_auth_tokens]"
-	}
-	return sql
 }

--- a/lib/db/logger.go
+++ b/lib/db/logger.go
@@ -4,6 +4,7 @@ package db
 
 import (
 	"context"
+	"strings"
 	"time"
 
 	"github.com/icco/gutil/logging"
@@ -56,9 +57,15 @@ func (l *GormLogger) Error(ctx context.Context, msg string, data ...interface{})
 }
 
 // Trace logs SQL query execution at debug level (or error level on failure).
+//
+// GORM renders trace SQL with parameter values already interpolated, so any
+// statement touching the OAuth token table would otherwise write live
+// access/refresh tokens into logs (at debug for every query, and at error on any
+// failed write regardless of log level). redactSQL scrubs those statements.
 func (l *GormLogger) Trace(ctx context.Context, begin time.Time, fc func() (sql string, rowsAffected int64), err error) {
 	elapsed := time.Since(begin)
 	sql, rows := fc()
+	sql = redactSQL(sql)
 	scoped := l.loggerFor(ctx)
 
 	if err != nil {
@@ -76,4 +83,14 @@ func (l *GormLogger) Trace(ctx context.Context, begin time.Time, fc func() (sql 
 		"rows", rows,
 		"elapsed", elapsed,
 	)
+}
+
+// redactSQL replaces statements that touch credential-bearing tables with a
+// placeholder so interpolated secrets never reach the logs.
+func redactSQL(sql string) string {
+	// GORM maps the OAuthToken model to the "o_auth_tokens" table.
+	if strings.Contains(strings.ToLower(sql), "o_auth_tokens") {
+		return "[redacted: statement touches o_auth_tokens]"
+	}
+	return sql
 }

--- a/lib/db/logger_test.go
+++ b/lib/db/logger_test.go
@@ -1,45 +1,23 @@
 package db
 
 import (
-	"strings"
+	"context"
 	"testing"
+
+	"go.uber.org/zap"
 )
 
-func TestRedactSQL(t *testing.T) {
-	cases := []struct {
-		name    string
-		sql     string
-		redacts bool
-	}{
-		{
-			name:    "oauth token upsert is redacted",
-			sql:     `INSERT INTO "o_auth_tokens" ("source","access_token","refresh_token") VALUES ('trakt','live-access','live-refresh')`,
-			redacts: true,
-		},
-		{
-			name:    "case-insensitive table match",
-			sql:     `SELECT * FROM O_AUTH_TOKENS WHERE source = 'trakt'`,
-			redacts: true,
-		},
-		{
-			name:    "ordinary query is untouched",
-			sql:     `SELECT * FROM movies WHERE year = 2001`,
-			redacts: false,
-		},
+// TestParamsFilterDropsValues verifies bound parameters are stripped so GORM
+// logs placeholders instead of interpolated values (keeping OAuth tokens and
+// other secrets out of query traces).
+func TestParamsFilterDropsValues(t *testing.T) {
+	l := NewGormLogger(zap.NewNop())
+	sql := `INSERT INTO "o_auth_tokens" ("access_token","refresh_token") VALUES ($1,$2)`
+	gotSQL, gotParams := l.ParamsFilter(context.Background(), sql, "live-access", "live-refresh")
+	if gotSQL != sql {
+		t.Fatalf("SQL altered: got %q want %q", gotSQL, sql)
 	}
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			got := redactSQL(tc.sql)
-			if tc.redacts {
-				if got == tc.sql {
-					t.Fatalf("expected redaction, got original SQL")
-				}
-				if strings.Contains(got, "live-access") || strings.Contains(got, "live-refresh") {
-					t.Fatalf("redacted SQL still leaked token values: %q", got)
-				}
-			} else if got != tc.sql {
-				t.Fatalf("non-sensitive SQL altered: got %q want %q", got, tc.sql)
-			}
-		})
+	if gotParams != nil {
+		t.Fatalf("expected params dropped, got %v", gotParams)
 	}
 }

--- a/lib/db/logger_test.go
+++ b/lib/db/logger_test.go
@@ -1,0 +1,45 @@
+package db
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestRedactSQL(t *testing.T) {
+	cases := []struct {
+		name    string
+		sql     string
+		redacts bool
+	}{
+		{
+			name:    "oauth token upsert is redacted",
+			sql:     `INSERT INTO "o_auth_tokens" ("source","access_token","refresh_token") VALUES ('trakt','live-access','live-refresh')`,
+			redacts: true,
+		},
+		{
+			name:    "case-insensitive table match",
+			sql:     `SELECT * FROM O_AUTH_TOKENS WHERE source = 'trakt'`,
+			redacts: true,
+		},
+		{
+			name:    "ordinary query is untouched",
+			sql:     `SELECT * FROM movies WHERE year = 2001`,
+			redacts: false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := redactSQL(tc.sql)
+			if tc.redacts {
+				if got == tc.sql {
+					t.Fatalf("expected redaction, got original SQL")
+				}
+				if strings.Contains(got, "live-access") || strings.Contains(got, "live-refresh") {
+					t.Fatalf("redacted SQL still leaked token values: %q", got)
+				}
+			} else if got != tc.sql {
+				t.Fatalf("non-sensitive SQL altered: got %q want %q", got, tc.sql)
+			}
+		})
+	}
+}

--- a/lib/plex/client.go
+++ b/lib/plex/client.go
@@ -42,15 +42,26 @@ const (
 	titleKey = "title"
 )
 
-// DownloadImage fetches a Plex image URL (adding the auth token) and writes it to
-// dest, creating parent directories as needed. Used to cache posters locally so
-// the public web page doesn't need to reach the private Plex host.
+// maxPosterBytes caps how much a single poster download may write to disk, so a
+// hostile or misbehaving image host can't exhaust local storage.
+const maxPosterBytes = 25 << 20 // 25 MiB
+
+// DownloadImage fetches an image URL and writes it to dest, creating parent
+// directories as needed. Used to cache posters locally so the public web page
+// doesn't need to reach the private Plex host.
+//
+// The private X-Plex-Token is attached ONLY when imageURL is hosted on the
+// configured Plex server. Plex thumb metadata can contain absolute third-party
+// URLs (or attacker-influenced ones from scraped metadata); sending the token to
+// an arbitrary host would leak it and enable SSRF with the service's credentials.
 func (c *Client) DownloadImage(ctx context.Context, imageURL, dest string) error {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, imageURL, nil)
 	if err != nil {
 		return err
 	}
-	req.Header.Set("X-Plex-Token", c.plexToken)
+	if sameHost(imageURL, c.plexURL) {
+		req.Header.Set("X-Plex-Token", c.plexToken)
+	}
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		return fmt.Errorf("fetch image: %w", err)
@@ -67,10 +78,24 @@ func (c *Client) DownloadImage(ctx context.Context, imageURL, dest string) error
 		return fmt.Errorf("create poster file: %w", err)
 	}
 	defer func() { _ = f.Close() }()
-	if _, err := io.Copy(f, resp.Body); err != nil {
+	if _, err := io.Copy(f, io.LimitReader(resp.Body, maxPosterBytes)); err != nil {
 		return fmt.Errorf("write poster: %w", err)
 	}
 	return nil
+}
+
+// sameHost reports whether two URLs target the same host:port. A parse failure
+// on either side returns false, so the caller fails closed (no token attached).
+func sameHost(a, b string) bool {
+	ua, err := url.Parse(a)
+	if err != nil {
+		return false
+	}
+	ub, err := url.Parse(b)
+	if err != nil {
+		return false
+	}
+	return ua.Host != "" && strings.EqualFold(ua.Host, ub.Host)
 }
 
 // NewClient creates a new Plex client with the provided configuration.

--- a/lib/plex/client.go
+++ b/lib/plex/client.go
@@ -42,18 +42,14 @@ const (
 	titleKey = "title"
 )
 
-// maxPosterBytes caps how much a single poster download may write to disk, so a
-// hostile or misbehaving image host can't exhaust local storage.
+// maxPosterBytes caps a single poster download so a misbehaving host can't fill
+// the disk.
 const maxPosterBytes = 25 << 20 // 25 MiB
 
-// DownloadImage fetches an image URL and writes it to dest, creating parent
-// directories as needed. Used to cache posters locally so the public web page
-// doesn't need to reach the private Plex host.
-//
-// The private X-Plex-Token is attached ONLY when imageURL is hosted on the
-// configured Plex server. Plex thumb metadata can contain absolute third-party
-// URLs (or attacker-influenced ones from scraped metadata); sending the token to
-// an arbitrary host would leak it and enable SSRF with the service's credentials.
+// DownloadImage fetches an image URL and writes it to dest. The X-Plex-Token is
+// attached only when imageURL is on the configured Plex host: thumb metadata can
+// carry absolute off-host URLs, and sending the token there would leak it and
+// allow SSRF with the service's credentials.
 func (c *Client) DownloadImage(ctx context.Context, imageURL, dest string) error {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, imageURL, nil)
 	if err != nil {

--- a/lib/plex/download_test.go
+++ b/lib/plex/download_test.go
@@ -1,0 +1,27 @@
+package plex
+
+import "testing"
+
+func TestSameHost(t *testing.T) {
+	cases := []struct {
+		name string
+		a    string
+		b    string
+		want bool
+	}{
+		{"identical plex host", "http://plex.local:32400/photo/x.jpg", "http://plex.local:32400", true},
+		{"case-insensitive host", "http://Plex.Local:32400/x.jpg", "http://plex.local:32400", true},
+		{"different host", "https://attacker.example/collect", "http://plex.local:32400", false},
+		{"internal metadata endpoint", "http://169.254.169.254/latest/meta-data/", "http://plex.local:32400", false},
+		{"different port", "http://plex.local:9999/x.jpg", "http://plex.local:32400", false},
+		{"unparseable image url", "://bad", "http://plex.local:32400", false},
+		{"empty host relative", "/library/metadata/1/thumb", "http://plex.local:32400", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := sameHost(tc.a, tc.b); got != tc.want {
+				t.Fatalf("sameHost(%q, %q) = %v, want %v", tc.a, tc.b, got, tc.want)
+			}
+		})
+	}
+}

--- a/lib/tmdb/client.go
+++ b/lib/tmdb/client.go
@@ -10,7 +10,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"strings"
+	"net/url"
 	"sync"
 	"time"
 
@@ -230,7 +230,7 @@ func (c *Client) SearchMovie(ctx context.Context, title string, year int) (*Sear
 	l := logging.FromContext(ctx)
 	// safeURL never includes the api key so it is safe to embed in errors and logs.
 	safeURL := fmt.Sprintf("%s/search/movie?query=%s&year=%d",
-		c.baseURL, strings.ReplaceAll(title, " ", "+"), year)
+		c.baseURL, url.QueryEscape(title), year)
 
 	retryFunc := func() (*SearchResult, error) {
 		if !c.circuitBreaker.canExecute() {
@@ -324,7 +324,7 @@ func (c *Client) SearchTVShow(ctx context.Context, title string, year int) (*TVS
 	l := logging.FromContext(ctx)
 	// safeURL never includes the api key so it is safe to embed in errors and logs.
 	safeURL := fmt.Sprintf("%s/search/tv?query=%s&first_air_date_year=%d",
-		c.baseURL, strings.ReplaceAll(title, " ", "+"), year)
+		c.baseURL, url.QueryEscape(title), year)
 
 	retryFunc := func() (*TVSearchResult, error) {
 		if !c.circuitBreaker.canExecute() {

--- a/main.go
+++ b/main.go
@@ -26,6 +26,7 @@ import (
 	"github.com/icco/recommender/static"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
+	"github.com/unrolled/secure"
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 	"go.opentelemetry.io/otel"
 	otelprom "go.opentelemetry.io/otel/exporters/prometheus"
@@ -161,8 +162,22 @@ func main() {
 
 	r := chi.NewRouter()
 
+	secureMiddleware := secure.New(secure.Options{
+		SSLRedirect:          false,
+		SSLProxyHeaders:      map[string]string{"X-Forwarded-Proto": "https"},
+		STSSeconds:           63072000,
+		STSIncludeSubdomains: true,
+		STSPreload:           true,
+		FrameDeny:            true,
+		ContentTypeNosniff:   true,
+		BrowserXssFilter:     true,
+		ReferrerPolicy:       "no-referrer",
+		PermissionsPolicy:    "geolocation=(), midi=(), sync-xhr=(), microphone=(), camera=(), magnetometer=(), gyroscope=(), fullscreen=(), payment=(), usb=()",
+	})
+
 	r.Use(logging.Middleware(log.Desugar()))
 	r.Use(routeTag)
+	r.Use(secureMiddleware.Handler)
 	r.Use(middleware.Timeout(60 * time.Second))
 
 	r.Handle("/static/*", http.StripPrefix("/static/", http.FileServer(http.FS(static.Files))))


### PR DESCRIPTION
Security audit fixes. No change to the recommendation flow.

- **Plex token exfil / SSRF:** `DownloadImage` sends `X-Plex-Token` only to the configured Plex host; poster downloads capped at 25 MiB.
- **Token log leak:** the GORM logger implements `gorm.ParamsFilter`, so SQL logs with placeholders and bound values (Trakt tokens, PII) never reach logs.
- **TMDb query injection:** search titles use `url.QueryEscape`.
- **Secure headers** via `unrolled/secure`, matching the other services.

`/cron/*` and `/metrics` stay unauthenticated by design; the README now documents restricting them at the ingress. Unit tests added for `sameHost` and `ParamsFilter`.