### PR TITLE
feat: add books as a third recommendation tier from Goodreads

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -398,6 +398,7 @@ Gemini prompts are in `lib/recommend/prompts/` and use Go templates with the sco
 - Goodreads covers are public on `i.gr-assets.com`, so `cachePoster` skips books rather than routing them through the Plex downloader
 - Books never get a `MetacriticURL`: Metacritic has no book section, so the slug would resolve to an unrelated film
 - Everything book-related fails soft. An unset `GOODREADS_USER_ID` or an unreachable Goodreads costs the books tier only; `TargetBooks` collapses to 0 and the prompt drops its books section
+- Shelves are large — Nat's are 1749 to-read and 1131 read (1112 rated) as of Aug 2026 — so the sync batches upserts (`upsertBatch`) rather than one round trip per row. It shares `cronBackgroundLockKey` with the Plex refresh, so per-row writes to `rope.local` would eat the budget. A shelf past `maxPages` returns `goodreads.ErrTruncated` *with* the partial results, so a capped pool is logged, not silently mistaken for a complete one
 
 **Plex Client:**
 - Ratings prefer `rating`, falling back to `audienceRating`. Plex sets `rating` on movies but **never** on shows (measured: 0 of 1408 shows had `rating`, 1397 had `audienceRating`), so decoding only `rating` rendered every TV card as 0.0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-This is a personalized content recommendation service that uses Gemini (on Vertex AI) to generate daily recommendations for movies and TV shows. The service integrates with Plex (for library data + GUIDs), TMDb (for fallback posters), and generates recommendations based on watch history, ratings, and a Plex-derived taste profile. All recommendations are titles already in the Plex library.
+This is a personalized content recommendation service that uses Gemini (on Vertex AI) to generate daily recommendations for movies, TV shows, and books. The service integrates with Plex (for library data + GUIDs), TMDb (for fallback posters), and generates recommendations based on watch history, ratings, and a Plex-derived taste profile. Movie and TV recommendations are titles already in the Plex library; book recommendations come from the user's Goodreads want-to-read shelf.
 
 ## Architecture
 
@@ -16,6 +16,7 @@ This is a personalized content recommendation service that uses Gemini (on Verte
 
 **Key Libraries:**
 - `lib/recommend/`: Gemini-powered recommendation generation — candidate scoring/shortlisting (`candidates.go`), ID-based slotting (`slotting.go`), the Gemini client (`llm.go`), the taste profile (`profile.go`), and the pipeline (`generate.go`)
+- `lib/goodreads/`: Goodreads shelf client over the per-shelf RSS feed. The official API was retired in Dec 2020 and issues no new keys, so RSS is the only supported public route; it needs no key or auth for a public profile. **The user id is from `/user/show/<id>`, a different namespace from `/author/show/<id>`** — passing an author id returns a different person's shelves with no error
 - `lib/plex/`: Plex API client for fetching library data
 - `lib/tmdb/`: TMDb API client with rate limiting and circuit breaker
 - `lib/omdb/`: OMDb API client (Metacritic Metascores) — same rate limit / circuit breaker / key-safe-URL shape as `lib/tmdb`
@@ -26,7 +27,7 @@ This is a personalized content recommendation service that uses Gemini (on Verte
 
 **Data Flow:**
 1. Cron endpoints (`/cron/recommend`, `/cron/cache`) trigger data collection from Plex/TMDb
-2. Recommendation engine scores cached titles, shortlists them (date-seeded), and uses Gemini to pick 4 movies + 3 TV shows daily by ID
+2. Recommendation engine scores cached titles, shortlists them (date-seeded), and uses Gemini to pick 4 movies + 3 TV shows + 3 books daily by ID
 3. Web interface serves recommendations with posters, ratings, and metadata
 
 ## Development Commands
@@ -74,6 +75,7 @@ docker compose down
 - `ANILIST_USERNAME`: enable AniList (public list) signals
 - `OMDB_API_KEY`: enable Metacritic Metascores (fetched via OMDb, joined on IMDb ID)
 - `OMDB_BATCH_SIZE`: OMDb lookups per cache run (defaults to 40, sized for OMDb's free 1000/day quota)
+- `GOODREADS_USER_ID`: Goodreads numeric user id; enables the books tier
 - `PORT`: HTTP server port (defaults to 8080)
 - `POSTER_DIR`: Directory for locally cached Plex posters (defaults to `posters`)
 
@@ -325,6 +327,11 @@ This workflow ensures code quality, prevents integration issues, and maintains a
 
 ## Database
 
+Two schema notes that bite silently:
+
+- **`recommendations.type` has a CHECK constraint.** GORM emits it only when it *creates* the column and never reconciles a changed one, so widening the allowed values requires an explicit `ALTER TABLE` **before** `AutoMigrate` (see `widenRecommendationTypeCheck`). Otherwise a pre-existing database rejects every row of a newly added type. The constraint is found by scanning `pg_constraint`, since GORM's generated name isn't guaranteed.
+- **Recommendation uniqueness is `(date, type, title)`, not `(date, title)`.** A book and a film routinely share a title (Dune), and the narrower key silently dropped one of the two.
+
 Uses Postgres with GORM ORM. Connection string comes from `DATABASE_URL`. Docker Compose runs a bundled `postgres:17` service; tests use an isolated schema per test on the Postgres named by `DATABASE_URL` (see `lib/dbtest`).
 
 **Schema Features:**
@@ -354,6 +361,7 @@ Any raw SQL must be Postgres dialect (e.g. `to_char()` for date formatting, not 
 The system generates exactly:
 - 4 movies: funny unwatched, action/drama unwatched, rewatchable, additional
 - 3 unwatched TV shows (with anime preference)
+- 3 books from the Goodreads want-to-read shelf (no role slots)
 
 **Concurrency Control:**
 - File-based locking prevents concurrent cron job execution
@@ -381,6 +389,15 @@ Gemini prompts are in `lib/recommend/prompts/` and use Go templates with the sco
 - Vertex AI backend via `google.golang.org/genai`, auth by ADC
 - JSON-constrained output via `ResponseMIMEType` + `ResponseSchema`
 - Isolated behind the `Chatter` interface so tests use a fake
+
+**Books (`lib/recommend/books.go`, `lib/goodreads`):**
+- Books are the one source that owns its candidate pool. Trakt/AniList/OMDb only re-rank owned Plex titles via `ExternalSignal`, which can join to a Movie or TVShow but not a Book; the want-to-read shelf *is* the recommendable set, so books get their own table
+- **Author affinity, not genre affinity.** The shelf feed has no genre field — only `user_shelves`, the user's own shelf names, which are near-empty on real accounts (measured on Nat's profile: 4 "fiction", 3 "digital-owned", 1 "top-ten" out of 100 read books). Read-shelf star ratings are rich by contrast (40× 5-star, 30× 4-star), so affinity keys on author
+- `Book.Rating` stores the Goodreads community average **rescaled ×2 to 0-10**, so one scoring path serves all three tiers. Cards divide back for display via `Recommendation.GoodreadsRating()`
+- `Shelf` is refreshed on every sync: a finished book moves from to-read to read, and a stale row would recommend it forever
+- Goodreads covers are public on `i.gr-assets.com`, so `cachePoster` skips books rather than routing them through the Plex downloader
+- Books never get a `MetacriticURL`: Metacritic has no book section, so the slug would resolve to an unrelated film
+- Everything book-related fails soft. An unset `GOODREADS_USER_ID` or an unreachable Goodreads costs the books tier only; `TargetBooks` collapses to 0 and the prompt drops its books section
 
 **Plex Client:**
 - Ratings prefer `rating`, falling back to `audienceRating`. Plex sets `rating` on movies but **never** on shows (measured: 0 of 1408 shows had `rating`, 1397 had `audienceRating`), so decoding only `rating` rendered every TV card as 0.0

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Recommender
 
-Daily movie and TV recommendations from your **Plex** library, enriched with **TMDb** metadata and chosen by **Gemini** (on Vertex AI). This is an experiment in building an app with generative AI.
+Daily movie, TV, and book recommendations — movies and TV from your **Plex** library, books from your **Goodreads** want-to-read shelf — enriched with **TMDb** metadata and chosen by **Gemini** (on Vertex AI). This is an experiment in building an app with generative AI.
 
 Stack: **Go**, **Chi** (routing), **GORM** (ORM), **Postgres**, **Gemini on Vertex AI** (`google.golang.org/genai`), **zap + gutil/logging** (JSON logs), **OpenTelemetry** (HTTP metrics on `/metrics`).
 
@@ -10,8 +10,9 @@ The home page shows one set of recommendations per calendar day:
 
 - Up to **four movies** (targets: comedy-leaning, action/drama, “rewatch” from titles marked watched in Plex, plus extras). Slot filling uses genre heuristics on the model output.
 - Up to **three TV shows**, drawn only from **unwatched** shows in the Plex cache (`ViewCount == 0`).
+- Up to **three books**, drawn from your Goodreads **want-to-read** shelf.
 
-Each card shows poster, title, year, rating, genre, and runtime (movies) or season count (TV).
+Each card shows poster, title, year, rating, genre, and runtime (movies), season count (TV), or author and page count (books). A tier's heading is omitted when it has no picks, so books simply don't appear unless Goodreads is configured.
 
 Past days are listed at `/dates` (one row per distinct day, paginated).
 
@@ -20,11 +21,13 @@ Past days are listed at `/dates` (one row per distinct day, paginated).
 - **Plex** — library scan, watch counts, GUIDs (imdb/tmdb/tvdb), full genres, and ratings during cache update. Ratings prefer Plex's critic `rating` and fall back to `audienceRating`, which is the only score Plex sets on TV shows
 - **TMDb** — fallback poster fill for the day's finalists when Plex has no poster
 - **Metacritic (via OMDb)** — critic Metascores for **movies only**, joined by IMDb ID; feeds ranking, prompt context, and a score badge + link on each card. OMDb carries no Metacritic data for TV at all (verified: 0 of 12 series scored, by title or IMDb id; the season and episode endpoints expose no score field), so shows are never looked up
+- **Goodreads** — the want-to-read shelf is the book pool; the read shelf's star ratings drive author affinity and prompt context. Read via the per-shelf RSS feed (`/review/list_rss/{userID}`), since the official API was retired in December 2020 and issues no new keys
 - **Gemini (Vertex AI)** — picks recommendations by ID from a scored shortlist via JSON-constrained output
 
 ### Not implemented (possible future work)
 
 - Letterboxd and other catalogs mentioned in earlier notes
+- Book genres. The shelf feed carries no genre field, only the user's own shelf names, which most accounts leave largely empty; books use author affinity instead
 - Metacritic scores for TV. Metacritic rates seasons, not series, and exposes them only on its own site — reaching them means scraping `metacritic.com/tv/<show>/season-N/`
 - Incremental “fill missing slots only” runs (each successful run replaces the whole day’s rows when incomplete)
 
@@ -61,6 +64,7 @@ Past days are listed at `/dates` (one row per distinct day, paginated).
 | `ANILIST_USERNAME` | no | AniList username (public list); enables AniList signals |
 | `OMDB_API_KEY` | no | [OMDb](https://www.omdbapi.com/apikey.aspx) key; enables Metacritic Metascores |
 | `OMDB_BATCH_SIZE` | no | OMDb lookups per cache run (default `40`, sized for OMDb's free 1000/day quota) |
+| `GOODREADS_USER_ID` | no | Goodreads numeric user id; enables the books tier |
 | `PORT` | no | HTTP port (default `8080`) |
 | `POSTER_DIR` | no | Directory for locally cached Plex posters (default `posters`; Docker Compose uses `/data/posters`) |
 
@@ -72,6 +76,7 @@ External sources only **re-rank titles you already own in Plex** — they never 
 
 - **Trakt** (watched / ratings / watchlist): register a Trakt API app, set `TRAKT_CLIENT_ID`/`TRAKT_CLIENT_SECRET` and a `TRAKT_CONNECT_TOKEN`, then authorize once — `curl "http://localhost:8080/trakt/connect?token=$TRAKT_CONNECT_TOKEN"` and enter the returned code at the Trakt URL. Tokens persist in the DB and auto-refresh.
 - **AniList** (anime scores): set `ANILIST_USERNAME` (public list; no auth). Matched to owned anime by title + year.
+- **Goodreads** (books): set `GOODREADS_USER_ID` to the number in your profile URL — `goodreads.com/user/show/12680-nat` → `12680`. This is a *different* namespace from the author id on `/author/show/<id>`, which will silently return someone else's shelves. The profile must be public; no auth or key is needed. Unlike the other sources, Goodreads doesn't just re-rank — the want-to-read shelf is the book candidate pool.
 - **Metacritic** (critic Metascores): set `OMDB_API_KEY`. Metacritic has no public API, so scores come from [OMDb](https://www.omdbapi.com/), joined on the IMDb ID Plex already provides. Enrichment is incremental: each cache run looks up `OMDB_BATCH_SIZE` titles that have never been checked, so the library backfills over a few days inside the free tier. A title that comes back with a score is never re-fetched — critic scores are final once a title is released. Titles Metacritic doesn't cover are stamped too and retried only after 90 days, to catch a late score without re-spending the quota every run. A run is also time-boxed, so a slow OMDb defers titles to the next run rather than holding the shared cron lock past the point where `/cron/recommend` can acquire it.
 
 Signals feed genre affinity, a watchlist score boost, watched-elsewhere handling, and a short "recently loved" line in the prompt.
@@ -85,6 +90,7 @@ recommender/
 ├── handlers/          # HTTP handlers and HTML templates (embedded)
 ├── lib/
 │   ├── db/           # Migrations and GORM logger
+│   ├── goodreads/    # Goodreads shelf client (RSS)
 │   ├── health/       # Health check
 │   ├── lock/         # File locks for cron endpoints
 │   ├── metacritic/   # metacritic.com link building

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,6 +20,7 @@ services:
       - GOOGLE_APPLICATION_CREDENTIALS=/secrets/gcp-sa.json
       - DATABASE_URL=${DATABASE_URL:-postgres://recommender:recommender@postgres:5432/recommender?sslmode=disable}
       - OMDB_API_KEY=${OMDB_API_KEY}
+      - GOODREADS_USER_ID=${GOODREADS_USER_ID}
       - OMDB_BATCH_SIZE=${OMDB_BATCH_SIZE}
       - POSTER_DIR=/data/posters
       - PORT=${PORT:-8080}

--- a/handlers/home_template_test.go
+++ b/handlers/home_template_test.go
@@ -105,3 +105,69 @@ func TestHomeRendersScoreWithoutLink(t *testing.T) {
 		t.Error("no link should be emitted when MetacriticURL is empty")
 	}
 }
+
+func TestHomeRendersBookCard(t *testing.T) {
+	t.Parallel()
+	out := renderHome(t, []models.Recommendation{{
+		Title: "Piranesi", Type: models.TypeBook, Year: 2020, Rating: 8.4,
+		Author: "Susanna Clarke", Runtime: 245, Date: time.Now(),
+		PosterURL: "https://i.gr-assets.com/books/1.jpg",
+		SourceURL: "https://www.goodreads.com/book/show/50202953",
+		Genre:     "fiction", Explanation: "strange and lovely",
+	}})
+
+	for _, want := range []string{
+		"Books", "Piranesi", "by Susanna Clarke", "245 pages",
+		"Shelves: fiction", "strange and lovely",
+		`href="https://www.goodreads.com/book/show/50202953"`,
+		`src="https://i.gr-assets.com/books/1.jpg"`,
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("missing %q in book card:\n%s", want, out)
+		}
+	}
+	// Stored on the 0-10 scale, shown on Goodreads' native 5-star scale.
+	if !strings.Contains(out, "Goodreads: 4.20/5") {
+		t.Errorf("want the rescaled 5-star rating:\n%s", out)
+	}
+	// Books have no Metascore, so no badge.
+	if strings.Contains(out, "Metacritic") {
+		t.Error("book card should not render a Metacritic badge")
+	}
+	// Screen tiers are absent, so their headings must be too.
+	if strings.Contains(out, ">Movies<") || strings.Contains(out, ">TV Shows<") {
+		t.Errorf("empty screen tiers should not render headings:\n%s", out)
+	}
+}
+
+// The books heading must not appear when Goodreads is unconfigured.
+func TestHomeOmitsBooksSectionWhenEmpty(t *testing.T) {
+	t.Parallel()
+	out := renderHome(t, []models.Recommendation{{
+		Title: "The Matrix", Type: models.TypeMovie, Year: 1999, Rating: 8.7,
+		Genre: "Action", Runtime: 136, Date: time.Now(),
+	}})
+	if strings.Contains(out, ">Books<") {
+		t.Errorf("Books heading rendered with no books:\n%s", out)
+	}
+	if !strings.Contains(out, ">Movies<") {
+		t.Error("Movies heading should render when movies are present")
+	}
+}
+
+// Books routinely lack year, cover, shelves, and page count. None of those may
+// render as a bare "0".
+func TestHomeBookCardOmitsMissingFields(t *testing.T) {
+	t.Parallel()
+	out := renderHome(t, []models.Recommendation{{
+		Title: "Goodbye Chinatown", Type: models.TypeBook, Author: "Kit Fan", Date: time.Now(),
+	}})
+	if !strings.Contains(out, "Goodbye Chinatown") {
+		t.Fatalf("title missing:\n%s", out)
+	}
+	for _, unwanted := range []string{"0 pages", "Shelves:", "Goodreads:", "<img"} {
+		if strings.Contains(out, unwanted) {
+			t.Errorf("rendered %q for an absent field:\n%s", unwanted, out)
+		}
+	}
+}

--- a/handlers/templates/home.html
+++ b/handlers/templates/home.html
@@ -22,8 +22,7 @@
   {{if .}}
   <h1 class="text-3xl font-bold mb-8">Recommendations for {{(index . 0).Date.Format "January 2, 2006"}}</h1>
 
-  {{/* Each tier is gated on having items rather than rendering an empty heading:
-       books are absent entirely unless Goodreads is configured. */}}
+  {{/* Tiers are gated on having items; books are absent unless Goodreads is set. */}}
   {{$movies := ofType "movie" .}}
   {{$tvshows := ofType "tvshow" .}}
   {{$books := ofType "book" .}}
@@ -74,11 +73,10 @@
   </section>
   {{end}}
 
-  {{/* Books, from the Goodreads want-to-read shelf. Covers are portrait and vary
-       in aspect ratio far more than film posters, so they get object-contain on a
-       neutral field rather than the object-cover crop used above. Year, shelves,
-       page count, and even the cover are all routinely missing from the shelf
-       feed, so each is conditional — an unconditional row would render "0". */}}
+  {{/* Books, from the Goodreads want-to-read shelf. Covers get object-contain
+       rather than the crop above: aspect ratios vary far more than film posters.
+       Year, shelves, pages, and cover are all routinely absent from the feed, so
+       each is conditional — an unconditional row would render "0". */}}
   {{if $books}}
   <section class="mb-12">
     <h2 class="text-2xl font-semibold mb-4">Books</h2>

--- a/handlers/templates/home.html
+++ b/handlers/templates/home.html
@@ -22,12 +22,18 @@
   {{if .}}
   <h1 class="text-3xl font-bold mb-8">Recommendations for {{(index . 0).Date.Format "January 2, 2006"}}</h1>
 
+  {{/* Each tier is gated on having items rather than rendering an empty heading:
+       books are absent entirely unless Goodreads is configured. */}}
+  {{$movies := ofType "movie" .}}
+  {{$tvshows := ofType "tvshow" .}}
+  {{$books := ofType "book" .}}
+
   <!-- Movies Section -->
+  {{if $movies}}
   <section class="mb-12">
     <h2 class="text-2xl font-semibold mb-4">Movies</h2>
     <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
-      {{range .}}
-      {{if eq .Type "movie"}}
+      {{range $movies}}
       <div class="bg-white rounded-lg shadow-md overflow-hidden">
         <img src="{{.PosterURL}}" alt="{{.Title}}" class="w-full h-64 object-cover">
         <div class="p-4">
@@ -41,16 +47,16 @@
         </div>
       </div>
       {{end}}
-      {{end}}
     </div>
   </section>
+  {{end}}
 
   <!-- TV Shows Section -->
+  {{if $tvshows}}
   <section class="mb-12">
     <h2 class="text-2xl font-semibold mb-4">TV Shows</h2>
     <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-      {{range .}}
-      {{if eq .Type "tvshow"}}
+      {{range $tvshows}}
       <div class="bg-white rounded-lg shadow-md overflow-hidden">
         <img src="{{.PosterURL}}" alt="{{.Title}}" class="w-full h-64 object-cover">
         <div class="p-4">
@@ -64,9 +70,42 @@
         </div>
       </div>
       {{end}}
+    </div>
+  </section>
+  {{end}}
+
+  {{/* Books, from the Goodreads want-to-read shelf. Covers are portrait and vary
+       in aspect ratio far more than film posters, so they get object-contain on a
+       neutral field rather than the object-cover crop used above. Year, shelves,
+       page count, and even the cover are all routinely missing from the shelf
+       feed, so each is conditional — an unconditional row would render "0". */}}
+  {{if $books}}
+  <section class="mb-12">
+    <h2 class="text-2xl font-semibold mb-4">Books</h2>
+    <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+      {{range $books}}
+      <div class="bg-white rounded-lg shadow-md overflow-hidden">
+        {{if .PosterURL}}
+        <img src="{{.PosterURL}}" alt="{{.Title}}" class="w-full h-64 object-contain bg-gray-100" loading="lazy" referrerpolicy="no-referrer">
+        {{end}}
+        <div class="p-4">
+          <h3 class="text-lg font-semibold">
+            {{if .SourceURL}}
+            <a href="{{.SourceURL}}" rel="noopener noreferrer" target="_blank" class="text-blue-600 hover:text-blue-800">{{.Title}}</a>
+            {{else}}{{.Title}}{{end}}
+          </h3>
+          {{if .Author}}<p class="text-gray-600">by {{.Author}}</p>{{end}}
+          {{if .Year}}<p class="text-gray-600">{{.Year}}</p>{{end}}
+          {{if .Rating}}<p class="text-gray-600">Goodreads: {{printf "%.2f" .GoodreadsRating}}/5</p>{{end}}
+          {{if .Genre}}<p class="text-gray-600">Shelves: {{.Genre}}</p>{{end}}
+          {{if .Runtime}}<p class="text-gray-600">{{.Runtime}} pages</p>{{end}}
+          {{if .Explanation}}<p class="text-gray-500 italic mt-2">{{.Explanation}}</p>{{end}}
+        </div>
+      </div>
       {{end}}
     </div>
   </section>
+  {{end}}
   {{else}}
   <div class="text-center py-12">
     <h1 class="text-3xl font-bold mb-4">No Recommendations Available</h1>

--- a/handlers/templates/parse.go
+++ b/handlers/templates/parse.go
@@ -1,6 +1,10 @@
 package templates
 
-import "html/template"
+import (
+	"html/template"
+
+	"github.com/icco/recommender/models"
+)
 
 // ParseTemplates parses HTML templates from the embedded filesystem.
 // It takes a variadic list of template file paths and returns a parsed template
@@ -13,7 +17,22 @@ func ParseTemplates(files ...string) (*template.Template, error) {
 		"subtract": func(a, b int) int {
 			return a - b
 		},
+		"ofType": ofType,
 	}
 
 	return template.New("").Funcs(funcMap).ParseFS(FS, files...)
+}
+
+// ofType selects the recommendations of one tier, so a page can both skip an
+// empty tier's heading and range over just that tier. The books tier is empty
+// whenever Goodreads is unconfigured, which would otherwise render a bare
+// "Books" heading over nothing.
+func ofType(recType string, recs []models.Recommendation) []models.Recommendation {
+	var out []models.Recommendation
+	for _, rec := range recs {
+		if rec.Type == recType {
+			out = append(out, rec)
+		}
+	}
+	return out
 }

--- a/handlers/templates/parse.go
+++ b/handlers/templates/parse.go
@@ -23,10 +23,8 @@ func ParseTemplates(files ...string) (*template.Template, error) {
 	return template.New("").Funcs(funcMap).ParseFS(FS, files...)
 }
 
-// ofType selects the recommendations of one tier, so a page can both skip an
-// empty tier's heading and range over just that tier. The books tier is empty
-// whenever Goodreads is unconfigured, which would otherwise render a bare
-// "Books" heading over nothing.
+// ofType selects one tier's recommendations, so a page can skip an empty tier's
+// heading rather than render a bare "Books" over nothing when Goodreads is off.
 func ofType(recType string, recs []models.Recommendation) []models.Recommendation {
 	var out []models.Recommendation
 	for _, rec := range recs {

--- a/handlers/templates/stats.html
+++ b/handlers/templates/stats.html
@@ -21,6 +21,12 @@
       <p class="text-3xl font-bold">{{.TotalTVShows}}</p>
     </div>
 
+    <!-- Total Books -->
+    <div class="bg-white rounded-lg shadow-md p-6">
+      <h2 class="text-xl font-semibold mb-2">Total Books</h2>
+      <p class="text-3xl font-bold">{{.TotalBooks}}</p>
+    </div>
+
     <!-- Date Range -->
     <div class="bg-white rounded-lg shadow-md p-6">
       <h2 class="text-xl font-semibold mb-2">Date Range</h2>
@@ -46,6 +52,14 @@
       <div class="bg-white rounded-lg shadow-md p-6">
         <h3 class="text-xl font-semibold mb-2">Total Cached TV Shows</h3>
         <p class="text-3xl font-bold">{{.TotalCachedTVShows}}</p>
+      </div>
+      <div class="bg-white rounded-lg shadow-md p-6">
+        <h3 class="text-xl font-semibold mb-2">Books Want-to-Read</h3>
+        <p class="text-3xl font-bold">{{.TotalShelvedBooks}}</p>
+      </div>
+      <div class="bg-white rounded-lg shadow-md p-6">
+        <h3 class="text-xl font-semibold mb-2">Books Read</h3>
+        <p class="text-3xl font-bold">{{.TotalReadBooks}}</p>
       </div>
     </div>
     <div class="mt-6">

--- a/lib/db/migrations.go
+++ b/lib/db/migrations.go
@@ -3,6 +3,7 @@ package db
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/icco/gutil/logging"
 	"github.com/icco/recommender/models"
@@ -38,6 +39,7 @@ var (
 		"idx_plex_animes_title",
 		"idx_plex_tv_shows_title",
 		"idx_recommendations_date",
+		"idx_recommendations_date_title", // superseded by (date, type, title): a book and a film can share a title
 		"idx_tv_shows_title",
 		"idx_tvshows_title_year", // same as movies
 	}
@@ -45,8 +47,15 @@ var (
 
 // RunMigrations runs all database migrations.
 func RunMigrations(ctx context.Context, db *gorm.DB) error {
+	// The `type` CHECK constraint must be widened before AutoMigrate, not after:
+	// AutoMigrate does not alter an existing CHECK on Postgres, so a database
+	// created before books existed would keep rejecting every book insert.
+	if err := widenRecommendationTypeCheck(ctx, db); err != nil {
+		return fmt.Errorf("widen recommendation type check: %w", err)
+	}
+
 	if err := db.WithContext(ctx).AutoMigrate(
-		&models.Movie{}, &models.TVShow{}, &models.Recommendation{},
+		&models.Movie{}, &models.TVShow{}, &models.Book{}, &models.Recommendation{},
 		&models.GenerationRun{}, &models.ExternalSignal{}, &models.OAuthToken{},
 	); err != nil {
 		return fmt.Errorf("failed to migrate database: %w", err)
@@ -70,6 +79,57 @@ func RunMigrations(ctx context.Context, db *gorm.DB) error {
 	createAdditionalIndexes(ctx, db)
 
 	return nil
+}
+
+// recommendationTypeCheck is the widened CHECK constraint allowing the book tier.
+const recommendationTypeCheck = `CHECK (type IN ('movie', 'tvshow', 'book'))`
+
+// widenRecommendationTypeCheck replaces any pre-existing CHECK constraint on
+// recommendations.type with one that also permits 'book'.
+//
+// GORM emits the CHECK from the model tag only when it creates the column, and
+// never reconciles a changed one, so a database migrated when the tag still read
+// IN ('movie','tvshow') would reject every book insert at the DB layer. The
+// constraint is found by scanning pg_constraint rather than by name, because the
+// generated name is not guaranteed. No-op on a database where the table does not
+// exist yet — AutoMigrate then creates the column with the current tag.
+func widenRecommendationTypeCheck(ctx context.Context, db *gorm.DB) error {
+	l := logging.FromContext(ctx)
+	if !db.WithContext(ctx).Migrator().HasTable(&models.Recommendation{}) {
+		return nil
+	}
+
+	var names []string
+	if err := db.WithContext(ctx).Raw(`
+		SELECT conname FROM pg_constraint
+		WHERE conrelid = 'recommendations'::regclass
+		  AND contype = 'c'
+		  AND pg_get_constraintdef(oid) ILIKE '%type%'`).Scan(&names).Error; err != nil {
+		return fmt.Errorf("find type check constraints: %w", err)
+	}
+
+	for _, name := range names {
+		// Constraint names come from pg_constraint, not user input, but they are
+		// still identifiers and must be quoted rather than bound as parameters.
+		if err := db.WithContext(ctx).Exec(
+			`ALTER TABLE recommendations DROP CONSTRAINT IF EXISTS ` + quoteIdent(name)).Error; err != nil {
+			return fmt.Errorf("drop constraint %s: %w", name, err)
+		}
+		l.Infow("Dropped recommendations type check constraint", "constraint", name)
+	}
+
+	if err := db.WithContext(ctx).Exec(
+		`ALTER TABLE recommendations ADD CONSTRAINT chk_recommendations_type ` + recommendationTypeCheck).Error; err != nil {
+		return fmt.Errorf("add widened type check: %w", err)
+	}
+	l.Infow("Added widened recommendations type check constraint", "types", "movie, tvshow, book")
+	return nil
+}
+
+// quoteIdent renders a Postgres identifier safely for interpolation, doubling
+// any embedded quotes.
+func quoteIdent(name string) string {
+	return `"` + strings.ReplaceAll(name, `"`, `""`) + `"`
 }
 
 func backfillPlexRatingKeys(ctx context.Context, db *gorm.DB) error {

--- a/lib/db/migrations.go
+++ b/lib/db/migrations.go
@@ -47,9 +47,8 @@ var (
 
 // RunMigrations runs all database migrations.
 func RunMigrations(ctx context.Context, db *gorm.DB) error {
-	// The `type` CHECK constraint must be widened before AutoMigrate, not after:
-	// AutoMigrate does not alter an existing CHECK on Postgres, so a database
-	// created before books existed would keep rejecting every book insert.
+	// Must run before AutoMigrate: AutoMigrate never alters an existing CHECK, so
+	// a pre-books database would keep rejecting every book insert.
 	if err := widenRecommendationTypeCheck(ctx, db); err != nil {
 		return fmt.Errorf("widen recommendation type check: %w", err)
 	}
@@ -84,15 +83,10 @@ func RunMigrations(ctx context.Context, db *gorm.DB) error {
 // recommendationTypeCheck is the widened CHECK constraint allowing the book tier.
 const recommendationTypeCheck = `CHECK (type IN ('movie', 'tvshow', 'book'))`
 
-// widenRecommendationTypeCheck replaces any pre-existing CHECK constraint on
-// recommendations.type with one that also permits 'book'.
-//
-// GORM emits the CHECK from the model tag only when it creates the column, and
-// never reconciles a changed one, so a database migrated when the tag still read
-// IN ('movie','tvshow') would reject every book insert at the DB layer. The
-// constraint is found by scanning pg_constraint rather than by name, because the
-// generated name is not guaranteed. No-op on a database where the table does not
-// exist yet — AutoMigrate then creates the column with the current tag.
+// widenRecommendationTypeCheck replaces any existing CHECK on
+// recommendations.type with one that also permits 'book'. Found by scanning
+// pg_constraint rather than by name, since GORM's generated name isn't
+// guaranteed. No-op before the table exists; AutoMigrate then uses the current tag.
 func widenRecommendationTypeCheck(ctx context.Context, db *gorm.DB) error {
 	l := logging.FromContext(ctx)
 	if !db.WithContext(ctx).Migrator().HasTable(&models.Recommendation{}) {
@@ -109,8 +103,7 @@ func widenRecommendationTypeCheck(ctx context.Context, db *gorm.DB) error {
 	}
 
 	for _, name := range names {
-		// Constraint names come from pg_constraint, not user input, but they are
-		// still identifiers and must be quoted rather than bound as parameters.
+		// Identifiers can't be bound as parameters, so quote instead.
 		if err := db.WithContext(ctx).Exec(
 			`ALTER TABLE recommendations DROP CONSTRAINT IF EXISTS ` + quoteIdent(name)).Error; err != nil {
 			return fmt.Errorf("drop constraint %s: %w", name, err)
@@ -126,8 +119,7 @@ func widenRecommendationTypeCheck(ctx context.Context, db *gorm.DB) error {
 	return nil
 }
 
-// quoteIdent renders a Postgres identifier safely for interpolation, doubling
-// any embedded quotes.
+// quoteIdent quotes a Postgres identifier, doubling embedded quotes.
 func quoteIdent(name string) string {
 	return `"` + strings.ReplaceAll(name, `"`, `""`) + `"`
 }

--- a/lib/db/migrations_test.go
+++ b/lib/db/migrations_test.go
@@ -30,3 +30,73 @@ func TestRunMigrations_createsNewTables(t *testing.T) {
 		t.Fatal("expected assigned ID")
 	}
 }
+
+func TestRunMigrations_acceptsBookRecommendations(t *testing.T) {
+	gdb := dbtest.New(t)
+	if err := RunMigrations(t.Context(), gdb); err != nil {
+		t.Fatalf("RunMigrations: %v", err)
+	}
+	if !gdb.Migrator().HasTable(&models.Book{}) {
+		t.Fatal("books table missing")
+	}
+	rec := models.Recommendation{
+		Date: time.Now().UTC().Truncate(24 * time.Hour), Title: "Piranesi",
+		Type: models.TypeBook, Year: 2020, Author: "Susanna Clarke",
+	}
+	if err := gdb.Create(&rec).Error; err != nil {
+		t.Fatalf("create book recommendation: %v", err)
+	}
+}
+
+// Simulates a database migrated before books existed: the old CHECK rejects
+// 'book', and AutoMigrate alone never replaces it.
+func TestRunMigrations_widensPreexistingTypeCheck(t *testing.T) {
+	gdb := dbtest.New(t)
+	if err := gdb.AutoMigrate(&models.Recommendation{}); err != nil {
+		t.Fatalf("initial migrate: %v", err)
+	}
+	for _, sql := range []string{
+		`ALTER TABLE recommendations DROP CONSTRAINT IF EXISTS chk_recommendations_type`,
+		`ALTER TABLE recommendations ADD CONSTRAINT chk_recommendations_type CHECK (type IN ('movie', 'tvshow'))`,
+	} {
+		if err := gdb.Exec(sql).Error; err != nil {
+			t.Fatalf("seed old constraint: %v", err)
+		}
+	}
+
+	date := time.Now().UTC().Truncate(24 * time.Hour)
+	old := models.Recommendation{Date: date, Title: "Rejected", Type: models.TypeBook}
+	if err := gdb.Create(&old).Error; err == nil {
+		t.Fatal("want the pre-books constraint to reject a book, got nil")
+	}
+
+	if err := RunMigrations(t.Context(), gdb); err != nil {
+		t.Fatalf("RunMigrations: %v", err)
+	}
+	if err := gdb.Create(&models.Recommendation{Date: date, Title: "Accepted", Type: models.TypeBook}).Error; err != nil {
+		t.Fatalf("create book after widening: %v", err)
+	}
+	// The widened constraint must still reject a bogus type.
+	if err := gdb.Create(&models.Recommendation{Date: date, Title: "Bogus", Type: "podcast"}).Error; err == nil {
+		t.Error("want an unknown type rejected, got nil")
+	}
+}
+
+// A book and a film sharing a title must both survive the same day.
+func TestRunMigrations_titleUniquenessIsPerType(t *testing.T) {
+	gdb := dbtest.New(t)
+	if err := RunMigrations(t.Context(), gdb); err != nil {
+		t.Fatalf("RunMigrations: %v", err)
+	}
+	date := time.Now().UTC().Truncate(24 * time.Hour)
+	if err := gdb.Create(&models.Recommendation{Date: date, Title: "Dune", Type: models.TypeMovie, Year: 2021}).Error; err != nil {
+		t.Fatalf("create movie: %v", err)
+	}
+	if err := gdb.Create(&models.Recommendation{Date: date, Title: "Dune", Type: models.TypeBook, Year: 1965}).Error; err != nil {
+		t.Fatalf("create book with the same title: %v", err)
+	}
+	// Same type and title on one day is still a conflict.
+	if err := gdb.Create(&models.Recommendation{Date: date, Title: "Dune", Type: models.TypeBook, Year: 1965}).Error; err == nil {
+		t.Error("want a duplicate (date, type, title) rejected, got nil")
+	}
+}

--- a/lib/goodreads/client.go
+++ b/lib/goodreads/client.go
@@ -1,10 +1,6 @@
-// Package goodreads reads a user's public bookshelves from Goodreads.
-//
-// Goodreads retired its official API in December 2020 and issues no new keys, so
-// the per-shelf RSS feed at /review/list_rss/{userID} is the only supported
-// public route. It needs no key and no auth for a public profile, and carries
-// everything we need: book id, title, author, ISBN, community average rating,
-// the user's own star rating, page count, publication year, and cover URLs.
+// Package goodreads reads a user's public bookshelves via the per-shelf RSS
+// feed. The official API was retired in December 2020 and issues no new keys;
+// the feed needs neither key nor auth for a public profile.
 package goodreads
 
 import (
@@ -22,15 +18,13 @@ import (
 const (
 	defaultURL = "https://www.goodreads.com"
 
-	// ShelfRead is the shelf of books the user has finished; the source of taste
-	// signal (their star ratings).
+	// ShelfRead carries the taste signal (the user's star ratings).
 	ShelfRead = "read"
-	// ShelfToRead is the "want to read" shelf, used as the recommendable pool.
+	// ShelfToRead is the recommendable pool.
 	ShelfToRead = "to-read"
 
-	// Goodreads serves 100 items per RSS page and returns an empty channel past
-	// the last page. maxPages bounds the walk so a feed that never empties (a
-	// server-side change repeating page 1, say) can't spin forever.
+	// 100 items per page; an empty channel follows the last one. Bounds the walk
+	// in case a feed stops advancing.
 	maxPages = 40
 )
 
@@ -47,22 +41,18 @@ func NewClient() *Client {
 
 // Book is one shelved book as the RSS feed reports it.
 type Book struct {
-	GoodreadsID string
-	Title       string
-	Author      string
-	ISBN        string
-	// AverageRating is the Goodreads community average on its native 0-5 scale.
-	AverageRating float64
-	// UserRating is the user's own stars, 1-5; 0 means unrated.
-	UserRating int
-	Year       int
-	Pages      int
-	CoverURL   string
-	// Shelves are the user's own shelf names for this book, which double as
-	// coarse genres when someone actually shelves by genre. Often empty.
-	Shelves []string
-	ReadAt  *time.Time
-	AddedAt *time.Time
+	GoodreadsID   string
+	Title         string
+	Author        string
+	ISBN          string
+	AverageRating float64 // community average, native 0-5 scale
+	UserRating    int     // the user's own stars 1-5; 0 = unrated
+	Year          int
+	Pages         int
+	CoverURL      string
+	Shelves       []string // the user's own shelf names; often empty
+	ReadAt        *time.Time
+	AddedAt       *time.Time
 }
 
 // rssItem mirrors the fields we consume from one <item> in the shelf feed.
@@ -77,9 +67,8 @@ type rssItem struct {
 	UserShelves   string `xml:"user_shelves"`
 	UserReadAt    string `xml:"user_read_at"`
 	UserDateAdded string `xml:"user_date_added"`
-	// The feed nests page count one level down, as <book id=…><num_pages>.
-	NumPages string `xml:"book>num_pages"`
-	// Largest cover the feed offers; the others are thumbnails.
+	NumPages      string `xml:"book>num_pages"` // nested one level down
+	// Largest cover offered; the others are thumbnails.
 	LargeImageURL  string `xml:"book_large_image_url"`
 	MediumImageURL string `xml:"book_medium_image_url"`
 	ImageURL       string `xml:"book_image_url"`
@@ -89,10 +78,9 @@ type rssFeed struct {
 	Items []rssItem `xml:"channel>item"`
 }
 
-// Shelf returns every book on one shelf, walking the feed's pages until one
-// comes back empty. userID is the numeric id from the profile URL
-// (goodreads.com/user/show/<id>-name), which is a different namespace from the
-// author id on /author/show/<id>.
+// Shelf returns every book on one shelf, walking pages until one comes back
+// empty. userID is from the profile URL (goodreads.com/user/show/<id>-name) —
+// a different namespace from the author id on /author/show/<id>.
 func (c *Client) Shelf(ctx context.Context, userID, shelf string) ([]Book, error) {
 	if strings.TrimSpace(userID) == "" {
 		return nil, fmt.Errorf("goodreads: empty user id")
@@ -120,8 +108,7 @@ func (c *Client) Shelf(ctx context.Context, userID, shelf string) ([]Book, error
 			out = append(out, b)
 			fresh++
 		}
-		// A page whose every book we already have means the feed stopped
-		// advancing; stop rather than request the same rows for maxPages.
+		// An all-duplicate page means the feed stopped advancing.
 		if fresh == 0 {
 			break
 		}
@@ -141,7 +128,11 @@ func (c *Client) page(ctx context.Context, userID, shelf string, page int) ([]rs
 	if err != nil {
 		return nil, err
 	}
-	resp, err := c.httpClient.Do(req)
+	hc := c.httpClient
+	if hc == nil {
+		hc = http.DefaultClient
+	}
+	resp, err := hc.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("goodreads fetch %s page %d: %w", shelf, page, err)
 	}
@@ -152,8 +143,7 @@ func (c *Client) page(ctx context.Context, userID, shelf string, page int) ([]rs
 		return nil, fmt.Errorf("goodreads read %s page %d: %w", shelf, page, err)
 	}
 	if resp.StatusCode >= 400 {
-		// A private or missing profile answers 404, so surface the status rather
-		// than treating it as an empty shelf.
+		// A private or missing profile 404s; that must not read as an empty shelf.
 		return nil, fmt.Errorf("goodreads: HTTP %d for shelf %q page %d", resp.StatusCode, shelf, page)
 	}
 
@@ -164,9 +154,8 @@ func (c *Client) page(ctx context.Context, userID, shelf string, page int) ([]rs
 	return feed.Items, nil
 }
 
-// convert maps a feed item to a Book, reporting false for rows too incomplete to
-// use. A book with no id can't be deduped or joined, and one with no title can't
-// be shown.
+// convert maps a feed item to a Book, reporting false for rows with no id (can't
+// dedupe) or no title (can't display).
 func convert(it rssItem) (Book, bool) {
 	id := strings.TrimSpace(it.BookID)
 	title := strings.TrimSpace(it.Title)
@@ -198,9 +187,8 @@ func BookURL(goodreadsID string) string {
 	return defaultURL + "/book/show/" + goodreadsID
 }
 
-// parseFloat reads a numeric feed field, yielding 0 for the empty or
-// unparseable values the feed regularly returns (missing year, page count, or
-// rating all arrive as "").
+// parseFloat reads a numeric feed field. Missing year, page count, and rating
+// all arrive as "", so unparseable yields 0.
 func parseFloat(s string) float64 {
 	f, err := strconv.ParseFloat(strings.TrimSpace(s), 64)
 	if err != nil {
@@ -209,13 +197,10 @@ func parseFloat(s string) float64 {
 	return f
 }
 
-// rssTimeLayouts are the formats the feed uses for its date fields. RFC1123Z
-// covers the usual "Mon, 02 Jan 2006 15:04:05 -0700"; the +0000 variant appears
-// on user_read_at.
 var rssTimeLayouts = []string{time.RFC1123Z, time.RFC1123}
 
-// parseTime reads a feed date, yielding nil when absent or unrecognized —
-// user_read_at is empty for most books.
+// parseTime yields nil when absent or unrecognized; user_read_at is empty for
+// most books.
 func parseTime(s string) *time.Time {
 	s = strings.TrimSpace(s)
 	if s == "" {
@@ -229,8 +214,7 @@ func parseTime(s string) *time.Time {
 	return nil
 }
 
-// splitShelves parses the comma-joined user_shelves field, dropping the shelf
-// bookkeeping names that carry no taste information.
+// splitShelves parses user_shelves, dropping bookkeeping names.
 func splitShelves(s string) []string {
 	var out []string
 	for _, p := range strings.Split(s, ",") {

--- a/lib/goodreads/client.go
+++ b/lib/goodreads/client.go
@@ -1,0 +1,253 @@
+// Package goodreads reads a user's public bookshelves from Goodreads.
+//
+// Goodreads retired its official API in December 2020 and issues no new keys, so
+// the per-shelf RSS feed at /review/list_rss/{userID} is the only supported
+// public route. It needs no key and no auth for a public profile, and carries
+// everything we need: book id, title, author, ISBN, community average rating,
+// the user's own star rating, page count, publication year, and cover URLs.
+package goodreads
+
+import (
+	"context"
+	"encoding/xml"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const (
+	defaultURL = "https://www.goodreads.com"
+
+	// ShelfRead is the shelf of books the user has finished; the source of taste
+	// signal (their star ratings).
+	ShelfRead = "read"
+	// ShelfToRead is the "want to read" shelf, used as the recommendable pool.
+	ShelfToRead = "to-read"
+
+	// Goodreads serves 100 items per RSS page and returns an empty channel past
+	// the last page. maxPages bounds the walk so a feed that never empties (a
+	// server-side change repeating page 1, say) can't spin forever.
+	maxPages = 40
+)
+
+// Client fetches shelves from Goodreads. URL is overridable for tests.
+type Client struct {
+	URL        string
+	httpClient *http.Client
+}
+
+// NewClient returns a Goodreads shelf client.
+func NewClient() *Client {
+	return &Client{URL: defaultURL, httpClient: &http.Client{Timeout: 30 * time.Second}}
+}
+
+// Book is one shelved book as the RSS feed reports it.
+type Book struct {
+	GoodreadsID string
+	Title       string
+	Author      string
+	ISBN        string
+	// AverageRating is the Goodreads community average on its native 0-5 scale.
+	AverageRating float64
+	// UserRating is the user's own stars, 1-5; 0 means unrated.
+	UserRating int
+	Year       int
+	Pages      int
+	CoverURL   string
+	// Shelves are the user's own shelf names for this book, which double as
+	// coarse genres when someone actually shelves by genre. Often empty.
+	Shelves []string
+	ReadAt  *time.Time
+	AddedAt *time.Time
+}
+
+// rssItem mirrors the fields we consume from one <item> in the shelf feed.
+type rssItem struct {
+	BookID        string `xml:"book_id"`
+	Title         string `xml:"title"`
+	AuthorName    string `xml:"author_name"`
+	ISBN          string `xml:"isbn"`
+	AverageRating string `xml:"average_rating"`
+	UserRating    string `xml:"user_rating"`
+	BookPublished string `xml:"book_published"`
+	UserShelves   string `xml:"user_shelves"`
+	UserReadAt    string `xml:"user_read_at"`
+	UserDateAdded string `xml:"user_date_added"`
+	// The feed nests page count one level down, as <book id=…><num_pages>.
+	NumPages string `xml:"book>num_pages"`
+	// Largest cover the feed offers; the others are thumbnails.
+	LargeImageURL  string `xml:"book_large_image_url"`
+	MediumImageURL string `xml:"book_medium_image_url"`
+	ImageURL       string `xml:"book_image_url"`
+}
+
+type rssFeed struct {
+	Items []rssItem `xml:"channel>item"`
+}
+
+// Shelf returns every book on one shelf, walking the feed's pages until one
+// comes back empty. userID is the numeric id from the profile URL
+// (goodreads.com/user/show/<id>-name), which is a different namespace from the
+// author id on /author/show/<id>.
+func (c *Client) Shelf(ctx context.Context, userID, shelf string) ([]Book, error) {
+	if strings.TrimSpace(userID) == "" {
+		return nil, fmt.Errorf("goodreads: empty user id")
+	}
+	var out []Book
+	seen := make(map[string]struct{})
+	for page := 1; page <= maxPages; page++ {
+		items, err := c.page(ctx, userID, shelf, page)
+		if err != nil {
+			return nil, err
+		}
+		if len(items) == 0 {
+			break
+		}
+		fresh := 0
+		for _, it := range items {
+			b, ok := convert(it)
+			if !ok {
+				continue
+			}
+			if _, dup := seen[b.GoodreadsID]; dup {
+				continue
+			}
+			seen[b.GoodreadsID] = struct{}{}
+			out = append(out, b)
+			fresh++
+		}
+		// A page whose every book we already have means the feed stopped
+		// advancing; stop rather than request the same rows for maxPages.
+		if fresh == 0 {
+			break
+		}
+	}
+	return out, nil
+}
+
+// page fetches and decodes a single RSS page of a shelf.
+func (c *Client) page(ctx context.Context, userID, shelf string, page int) ([]rssItem, error) {
+	u := fmt.Sprintf("%s/review/list_rss/%s?%s", strings.TrimSuffix(c.URL, "/"),
+		url.PathEscape(userID), url.Values{
+			"shelf": {shelf},
+			"page":  {strconv.Itoa(page)},
+		}.Encode())
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u, nil)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("goodreads fetch %s page %d: %w", shelf, page, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("goodreads read %s page %d: %w", shelf, page, err)
+	}
+	if resp.StatusCode >= 400 {
+		// A private or missing profile answers 404, so surface the status rather
+		// than treating it as an empty shelf.
+		return nil, fmt.Errorf("goodreads: HTTP %d for shelf %q page %d", resp.StatusCode, shelf, page)
+	}
+
+	var feed rssFeed
+	if err := xml.Unmarshal(body, &feed); err != nil {
+		return nil, fmt.Errorf("goodreads decode %s page %d: %w", shelf, page, err)
+	}
+	return feed.Items, nil
+}
+
+// convert maps a feed item to a Book, reporting false for rows too incomplete to
+// use. A book with no id can't be deduped or joined, and one with no title can't
+// be shown.
+func convert(it rssItem) (Book, bool) {
+	id := strings.TrimSpace(it.BookID)
+	title := strings.TrimSpace(it.Title)
+	if id == "" || title == "" {
+		return Book{}, false
+	}
+	b := Book{
+		GoodreadsID:   id,
+		Title:         title,
+		Author:        strings.TrimSpace(it.AuthorName),
+		ISBN:          strings.TrimSpace(it.ISBN),
+		AverageRating: parseFloat(it.AverageRating),
+		UserRating:    int(parseFloat(it.UserRating)),
+		Year:          int(parseFloat(it.BookPublished)),
+		Pages:         int(parseFloat(it.NumPages)),
+		CoverURL:      firstNonEmpty(it.LargeImageURL, it.MediumImageURL, it.ImageURL),
+		Shelves:       splitShelves(it.UserShelves),
+		ReadAt:        parseTime(it.UserReadAt),
+		AddedAt:       parseTime(it.UserDateAdded),
+	}
+	return b, true
+}
+
+// BookURL is the goodreads.com page for a book id.
+func BookURL(goodreadsID string) string {
+	if strings.TrimSpace(goodreadsID) == "" {
+		return ""
+	}
+	return defaultURL + "/book/show/" + goodreadsID
+}
+
+// parseFloat reads a numeric feed field, yielding 0 for the empty or
+// unparseable values the feed regularly returns (missing year, page count, or
+// rating all arrive as "").
+func parseFloat(s string) float64 {
+	f, err := strconv.ParseFloat(strings.TrimSpace(s), 64)
+	if err != nil {
+		return 0
+	}
+	return f
+}
+
+// rssTimeLayouts are the formats the feed uses for its date fields. RFC1123Z
+// covers the usual "Mon, 02 Jan 2006 15:04:05 -0700"; the +0000 variant appears
+// on user_read_at.
+var rssTimeLayouts = []string{time.RFC1123Z, time.RFC1123}
+
+// parseTime reads a feed date, yielding nil when absent or unrecognized —
+// user_read_at is empty for most books.
+func parseTime(s string) *time.Time {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return nil
+	}
+	for _, layout := range rssTimeLayouts {
+		if t, err := time.Parse(layout, s); err == nil {
+			return &t
+		}
+	}
+	return nil
+}
+
+// splitShelves parses the comma-joined user_shelves field, dropping the shelf
+// bookkeeping names that carry no taste information.
+func splitShelves(s string) []string {
+	var out []string
+	for _, p := range strings.Split(s, ",") {
+		t := strings.TrimSpace(p)
+		if t == "" || t == ShelfRead || t == ShelfToRead || t == "currently-reading" {
+			continue
+		}
+		out = append(out, t)
+	}
+	return out
+}
+
+func firstNonEmpty(vals ...string) string {
+	for _, v := range vals {
+		if t := strings.TrimSpace(v); t != "" {
+			return t
+		}
+	}
+	return ""
+}

--- a/lib/goodreads/client.go
+++ b/lib/goodreads/client.go
@@ -6,6 +6,7 @@ package goodreads
 import (
 	"context"
 	"encoding/xml"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -27,6 +28,10 @@ const (
 	// in case a feed stops advancing.
 	maxPages = 40
 )
+
+// ErrTruncated reports that a shelf is larger than maxPages covers. The books
+// read so far are still returned, so callers can use a partial pool knowingly.
+var ErrTruncated = errors.New("goodreads: shelf truncated")
 
 // Client fetches shelves from Goodreads. URL is overridable for tests.
 type Client struct {
@@ -81,18 +86,23 @@ type rssFeed struct {
 // Shelf returns every book on one shelf, walking pages until one comes back
 // empty. userID is from the profile URL (goodreads.com/user/show/<id>-name) —
 // a different namespace from the author id on /author/show/<id>.
+//
+// Returns ErrTruncated alongside the books it did collect if the shelf is larger
+// than maxPages can cover, so a capped pool is never mistaken for a complete one.
 func (c *Client) Shelf(ctx context.Context, userID, shelf string) ([]Book, error) {
 	if strings.TrimSpace(userID) == "" {
 		return nil, fmt.Errorf("goodreads: empty user id")
 	}
 	var out []Book
 	seen := make(map[string]struct{})
+	complete := false
 	for page := 1; page <= maxPages; page++ {
 		items, err := c.page(ctx, userID, shelf, page)
 		if err != nil {
 			return nil, err
 		}
 		if len(items) == 0 {
+			complete = true
 			break
 		}
 		fresh := 0
@@ -110,8 +120,13 @@ func (c *Client) Shelf(ctx context.Context, userID, shelf string) ([]Book, error
 		}
 		// An all-duplicate page means the feed stopped advancing.
 		if fresh == 0 {
+			complete = true
 			break
 		}
+	}
+	if !complete {
+		return out, fmt.Errorf("%w: shelf %q exceeds %d pages (%d books read)",
+			ErrTruncated, shelf, maxPages, len(out))
 	}
 	return out, nil
 }

--- a/lib/goodreads/client_test.go
+++ b/lib/goodreads/client_test.go
@@ -2,6 +2,7 @@ package goodreads
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -242,5 +243,25 @@ func TestBookURL(t *testing.T) {
 	}
 	if got := BookURL(""); got != "" {
 		t.Errorf("BookURL(\"\") = %q, want empty", got)
+	}
+}
+
+// A shelf larger than maxPages must report ErrTruncated with the books it did
+// read, so a capped pool is never mistaken for a complete one.
+func TestShelf_reportsTruncation(t *testing.T) {
+	id := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		id++
+		_, _ = fmt.Fprint(w, feed(feedItem(fmt.Sprint(id), fmt.Sprintf("Book %d", id), "A", "")))
+	}))
+	defer srv.Close()
+
+	c := &Client{URL: srv.URL, httpClient: srv.Client()}
+	books, err := c.Shelf(context.Background(), "12680", ShelfToRead)
+	if !errors.Is(err, ErrTruncated) {
+		t.Fatalf("err = %v, want ErrTruncated", err)
+	}
+	if len(books) != maxPages {
+		t.Errorf("got %d books, want the %d pages read before the cap", len(books), maxPages)
 	}
 }

--- a/lib/goodreads/client_test.go
+++ b/lib/goodreads/client_test.go
@@ -1,0 +1,246 @@
+package goodreads
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// feedItem renders one <item> as the real feed does, with the nested
+// <book><num_pages> element and CDATA-wrapped text.
+func feedItem(id, title, author string, extra string) string {
+	return fmt.Sprintf(`<item>
+    <guid><![CDATA[https://www.goodreads.com/review/show/%s]]></guid>
+    <title><![CDATA[%s]]></title>
+    <book_id>%s</book_id>
+    <book_large_image_url><![CDATA[https://i.gr-assets.com/books/%s.jpg]]></book_large_image_url>
+    <book id="%s"><num_pages>210</num_pages></book>
+    <author_name>%s</author_name>
+    %s
+  </item>`, id, title, id, id, id, author, extra)
+}
+
+func feed(items ...string) string {
+	body := ""
+	for _, it := range items {
+		body += it
+	}
+	return `<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0"><channel><title><![CDATA[Nat's bookshelf: read]]></title>` + body + `</channel></rss>`
+}
+
+func TestShelf_parsesFeedFields(t *testing.T) {
+	item := feedItem("807968", "A Wizard of Earthsea (Earthsea Cycle, #1)", "Ursula K. Le Guin", `
+    <isbn>0544084373</isbn>
+    <user_rating>5</user_rating>
+    <average_rating>4.03</average_rating>
+    <book_published>1968</book_published>
+    <user_shelves>fiction, top-ten, read</user_shelves>
+    <user_read_at><![CDATA[Mon, 27 Jul 2026 00:00:00 +0000]]></user_read_at>
+    <user_date_added><![CDATA[Mon, 27 Jul 2026 20:47:23 -0700]]></user_date_added>`)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Query().Get("page") == "1" {
+			_, _ = fmt.Fprint(w, feed(item))
+			return
+		}
+		_, _ = fmt.Fprint(w, feed())
+	}))
+	defer srv.Close()
+
+	c := &Client{URL: srv.URL, httpClient: srv.Client()}
+	books, err := c.Shelf(context.Background(), "12680", ShelfRead)
+	if err != nil {
+		t.Fatalf("Shelf: %v", err)
+	}
+	if len(books) != 1 {
+		t.Fatalf("got %d books, want 1", len(books))
+	}
+
+	b := books[0]
+	if b.GoodreadsID != "807968" {
+		t.Errorf("GoodreadsID = %q, want 807968", b.GoodreadsID)
+	}
+	if b.Title != "A Wizard of Earthsea (Earthsea Cycle, #1)" {
+		t.Errorf("Title = %q", b.Title)
+	}
+	if b.Author != "Ursula K. Le Guin" {
+		t.Errorf("Author = %q", b.Author)
+	}
+	if b.AverageRating != 4.03 {
+		t.Errorf("AverageRating = %v, want 4.03", b.AverageRating)
+	}
+	if b.UserRating != 5 {
+		t.Errorf("UserRating = %d, want 5", b.UserRating)
+	}
+	if b.Year != 1968 {
+		t.Errorf("Year = %d, want 1968", b.Year)
+	}
+	if b.Pages != 210 { // nested under <book id=…>
+		t.Errorf("Pages = %d, want 210", b.Pages)
+	}
+	if b.CoverURL != "https://i.gr-assets.com/books/807968.jpg" {
+		t.Errorf("CoverURL = %q", b.CoverURL)
+	}
+	// "read" is bookkeeping, not a genre.
+	if len(b.Shelves) != 2 || b.Shelves[0] != "fiction" || b.Shelves[1] != "top-ten" {
+		t.Errorf("Shelves = %v, want [fiction top-ten]", b.Shelves)
+	}
+	if b.ReadAt == nil || b.ReadAt.Year() != 2026 {
+		t.Errorf("ReadAt = %v, want a 2026 time", b.ReadAt)
+	}
+	if b.AddedAt == nil {
+		t.Error("AddedAt = nil, want a time")
+	}
+}
+
+// The to-read shelf routinely omits year, rating, and read date; those must
+// decode as zero values rather than failing the page.
+func TestShelf_toleratesMissingFields(t *testing.T) {
+	item := feedItem("55399", "Goodbye Chinatown", "Kit Fan", `
+    <isbn></isbn>
+    <user_rating>0</user_rating>
+    <average_rating>3.56</average_rating>
+    <book_published></book_published>
+    <user_shelves>to-read</user_shelves>
+    <user_read_at></user_read_at>`)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Query().Get("page") == "1" {
+			_, _ = fmt.Fprint(w, feed(item))
+			return
+		}
+		_, _ = fmt.Fprint(w, feed())
+	}))
+	defer srv.Close()
+
+	c := &Client{URL: srv.URL, httpClient: srv.Client()}
+	books, err := c.Shelf(context.Background(), "12680", ShelfToRead)
+	if err != nil {
+		t.Fatalf("Shelf: %v", err)
+	}
+	if len(books) != 1 {
+		t.Fatalf("got %d books, want 1", len(books))
+	}
+	b := books[0]
+	if b.Year != 0 {
+		t.Errorf("Year = %d, want 0 for an absent book_published", b.Year)
+	}
+	if b.UserRating != 0 {
+		t.Errorf("UserRating = %d, want 0", b.UserRating)
+	}
+	if b.ReadAt != nil {
+		t.Errorf("ReadAt = %v, want nil for an empty user_read_at", b.ReadAt)
+	}
+	if len(b.Shelves) != 0 { // "to-read" is bookkeeping too
+		t.Errorf("Shelves = %v, want empty", b.Shelves)
+	}
+}
+
+func TestShelf_walksPagesUntilEmpty(t *testing.T) {
+	var pages []string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		page := r.URL.Query().Get("page")
+		pages = append(pages, page)
+		switch page {
+		case "1":
+			_, _ = fmt.Fprint(w, feed(feedItem("1", "One", "A", ""), feedItem("2", "Two", "B", "")))
+		case "2":
+			_, _ = fmt.Fprint(w, feed(feedItem("3", "Three", "C", "")))
+		default:
+			_, _ = fmt.Fprint(w, feed())
+		}
+	}))
+	defer srv.Close()
+
+	c := &Client{URL: srv.URL, httpClient: srv.Client()}
+	books, err := c.Shelf(context.Background(), "12680", ShelfToRead)
+	if err != nil {
+		t.Fatalf("Shelf: %v", err)
+	}
+	if len(books) != 3 {
+		t.Fatalf("got %d books, want 3 across two pages", len(books))
+	}
+	if len(pages) != 3 {
+		t.Errorf("requested pages %v, want three requests ending in an empty page", pages)
+	}
+}
+
+// A feed that ignores the page parameter must not spin for maxPages.
+func TestShelf_stopsOnRepeatedPage(t *testing.T) {
+	requests := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		requests++
+		_, _ = fmt.Fprint(w, feed(feedItem("1", "One", "A", "")))
+	}))
+	defer srv.Close()
+
+	c := &Client{URL: srv.URL, httpClient: srv.Client()}
+	books, err := c.Shelf(context.Background(), "12680", ShelfToRead)
+	if err != nil {
+		t.Fatalf("Shelf: %v", err)
+	}
+	if len(books) != 1 {
+		t.Errorf("got %d books, want 1 deduped", len(books))
+	}
+	if requests > 2 {
+		t.Errorf("made %d requests, want to stop after the first repeat", requests)
+	}
+}
+
+// A 404 (private or missing profile) must not read as an empty shelf, which
+// would wipe the candidate pool.
+func TestShelf_errorsOnHTTPFailure(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	c := &Client{URL: srv.URL, httpClient: srv.Client()}
+	if _, err := c.Shelf(context.Background(), "12680", ShelfToRead); err == nil {
+		t.Fatal("Shelf: want error on HTTP 404, got nil")
+	}
+}
+
+func TestShelf_rejectsEmptyUserID(t *testing.T) {
+	c := NewClient()
+	if _, err := c.Shelf(context.Background(), "  ", ShelfToRead); err == nil {
+		t.Fatal("Shelf: want error on empty user id, got nil")
+	}
+}
+
+// Rows with no id or title are dropped without failing the page.
+func TestShelf_skipsUnusableItems(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Query().Get("page") != "1" {
+			_, _ = fmt.Fprint(w, feed())
+			return
+		}
+		_, _ = fmt.Fprint(w, feed(
+			`<item><book_id></book_id><title><![CDATA[No ID]]></title></item>`,
+			`<item><book_id>42</book_id><title></title></item>`,
+			feedItem("7", "Real Book", "Author", ""),
+		))
+	}))
+	defer srv.Close()
+
+	c := &Client{URL: srv.URL, httpClient: srv.Client()}
+	books, err := c.Shelf(context.Background(), "12680", ShelfToRead)
+	if err != nil {
+		t.Fatalf("Shelf: %v", err)
+	}
+	if len(books) != 1 || books[0].GoodreadsID != "7" {
+		t.Fatalf("got %+v, want only the complete book", books)
+	}
+}
+
+func TestBookURL(t *testing.T) {
+	if got := BookURL("807968"); got != "https://www.goodreads.com/book/show/807968" {
+		t.Errorf("BookURL = %q", got)
+	}
+	if got := BookURL(""); got != "" {
+		t.Errorf("BookURL(\"\") = %q, want empty", got)
+	}
+}

--- a/lib/recommend/books.go
+++ b/lib/recommend/books.go
@@ -1,0 +1,274 @@
+package recommend
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/icco/gutil/logging"
+	"github.com/icco/recommender/lib/goodreads"
+	"github.com/icco/recommender/models"
+	"go.uber.org/zap"
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+)
+
+// goodreadsSource mirrors the user's Goodreads shelves into the books table.
+//
+// Unlike the other SignalSources, which write ExternalSignal rows to re-rank
+// owned Plex titles, this one owns its candidate pool: the to-read shelf *is*
+// the recommendable set, and the read shelf carries the taste signal in its star
+// ratings. Books therefore live in their own table rather than in ExternalSignal,
+// which can only join to a Movie or TVShow.
+type goodreadsSource struct {
+	db     *gorm.DB
+	client *goodreads.Client
+	userID string
+}
+
+func (s *goodreadsSource) Name() string { return models.SourceGoodreads }
+
+// goodreadsRatingScale converts Goodreads' 0-5 stars to the 0-10 scale Movie and
+// TVShow ratings use, so book candidates score and render on the same axis.
+const goodreadsRatingScale = 2.0
+
+// Sync refreshes both shelves. Shelf membership is refreshed on every run
+// because a book moves from to-read to read once finished, and a stale row would
+// keep recommending a book the user has already read.
+func (s *goodreadsSource) Sync(ctx context.Context) (int, error) {
+	l := logging.FromContext(ctx)
+	now := time.Now()
+	count := 0
+	for _, shelf := range []string{goodreads.ShelfRead, goodreads.ShelfToRead} {
+		books, err := s.client.Shelf(ctx, s.userID, shelf)
+		if err != nil {
+			// One unreachable shelf shouldn't discard the other: the to-read pool
+			// is still usable without a refreshed read shelf, and vice versa.
+			l.Warnw("goodreads shelf fetch failed", "shelf", shelf, zap.Error(err))
+			continue
+		}
+		for _, b := range books {
+			row := models.Book{
+				GoodreadsID: b.GoodreadsID,
+				Title:       b.Title,
+				Author:      b.Author,
+				Year:        b.Year,
+				Rating:      b.AverageRating * goodreadsRatingScale,
+				UserRating:  b.UserRating,
+				Shelf:       shelf,
+				Genre:       strings.Join(b.Shelves, ", "),
+				CoverURL:    b.CoverURL,
+				ISBN:        b.ISBN,
+				Pages:       b.Pages,
+				ReadAt:      b.ReadAt,
+				AddedAt:     b.AddedAt,
+				SyncedAt:    now,
+			}
+			if err := s.upsert(ctx, row); err != nil {
+				l.Warnw("upsert book failed", "goodreads_id", b.GoodreadsID, zap.Error(err))
+				continue
+			}
+			count++
+		}
+		l.Infow("goodreads shelf synced", "shelf", shelf, "books", len(books))
+	}
+	if count == 0 {
+		return 0, fmt.Errorf("goodreads: no books synced for user %q", s.userID)
+	}
+	return count, nil
+}
+
+// upsert inserts or refreshes one book on its Goodreads id.
+func (s *goodreadsSource) upsert(ctx context.Context, b models.Book) error {
+	return s.db.WithContext(ctx).Clauses(clause.OnConflict{
+		Columns: []clause.Column{{Name: "goodreads_id"}},
+		DoUpdates: clause.AssignmentColumns([]string{
+			"title", "author", "year", "rating", "user_rating", "shelf",
+			"genre", "cover_url", "isbn", "pages", "read_at", "added_at",
+			"synced_at", "updated_at",
+		}),
+	}).Create(&b).Error
+}
+
+// authorAffinity computes a normalized (0..1) taste weight per author from the
+// read shelf's star ratings.
+//
+// Books get author affinity where movies and TV get genre affinity, because the
+// Goodreads feed carries no genre field — only the user's own shelf names, which
+// most accounts leave empty. An author the user rated highly is both available
+// and a stronger signal for books than a genre would be.
+func (r *Recommender) authorAffinity(ctx context.Context) (map[string]float64, error) {
+	var read []models.Book
+	if err := r.db.WithContext(ctx).
+		Where("shelf = ? AND user_rating > 0", models.ShelfRead).
+		Find(&read).Error; err != nil {
+		return nil, fmt.Errorf("affinity books: %w", err)
+	}
+
+	// Center on 3 stars so a book the user actively disliked pushes its author
+	// down instead of merely failing to push them up.
+	raw := make(map[string]float64)
+	for _, b := range read {
+		author := normalizeAuthor(b.Author)
+		if author == "" {
+			continue
+		}
+		raw[author] += float64(b.UserRating) - 3.0
+	}
+
+	peak := 0.0
+	for _, v := range raw {
+		if v > peak {
+			peak = v
+		}
+	}
+	if peak == 0 {
+		return map[string]float64{}, nil
+	}
+	out := make(map[string]float64, len(raw))
+	for a, v := range raw {
+		out[a] = v / peak
+	}
+	return out, nil
+}
+
+// normalizeAuthor lowercases and trims an author name for affinity keying.
+func normalizeAuthor(s string) string {
+	return strings.ToLower(strings.TrimSpace(s))
+}
+
+// loadBookCandidates loads the to-read shelf as candidates, excluding books
+// recommended within the last `days` days.
+func (r *Recommender) loadBookCandidates(ctx context.Context, date time.Time, days int) ([]candidate, error) {
+	exclude, err := r.recentlyRecommendedBookIDs(ctx, date, days)
+	if err != nil {
+		return nil, err
+	}
+
+	aff, err := r.authorAffinity(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	var books []models.Book
+	if err := r.db.WithContext(ctx).Where("shelf = ?", models.ShelfToRead).Find(&books).Error; err != nil {
+		return nil, fmt.Errorf("load books: %w", err)
+	}
+
+	var out []candidate
+	for _, b := range books {
+		if _, skip := exclude[b.ID]; skip {
+			continue
+		}
+		out = append(out, candidate{
+			ID: b.ID, Type: models.TypeBook, Title: b.Title, Year: b.Year,
+			Rating: b.Rating, Genres: splitGenres(b.Genre), PosterURL: b.CoverURL,
+			Runtime: b.Pages, Author: b.Author, SourceURL: goodreads.BookURL(b.GoodreadsID),
+			Affinity: aff[normalizeAuthor(b.Author)],
+		})
+	}
+	return out, nil
+}
+
+// recentlyRecommendedBookIDs returns Book IDs recommended within the last `days` days.
+func (r *Recommender) recentlyRecommendedBookIDs(ctx context.Context, date time.Time, days int) (map[uint]struct{}, error) {
+	cutoff := date.AddDate(0, 0, -days)
+	var recs []models.Recommendation
+	if err := r.db.WithContext(ctx).
+		Where(`"date" >= ? AND "date" <= ? AND book_id IS NOT NULL`, cutoff, date).
+		Find(&recs).Error; err != nil {
+		return nil, fmt.Errorf("load recent book recommendations: %w", err)
+	}
+	out := make(map[uint]struct{})
+	for _, rec := range recs {
+		if rec.BookID != nil {
+			out[*rec.BookID] = struct{}{}
+		}
+	}
+	return out, nil
+}
+
+// lovedBooks summarizes up to 5 of the user's highest-rated finished books for
+// prompt context. Titles and authors let the model reason about literary taste,
+// which the empty genre column cannot.
+func (r *Recommender) lovedBooks(ctx context.Context) (string, error) {
+	var books []models.Book
+	if err := r.db.WithContext(ctx).
+		Where("shelf = ? AND user_rating >= 4", models.ShelfRead).
+		Order("user_rating DESC, read_at DESC NULLS LAST").
+		Limit(5).Find(&books).Error; err != nil {
+		return "", fmt.Errorf("loved books: %w", err)
+	}
+	if len(books) == 0 {
+		return "", nil
+	}
+	parts := make([]string, 0, len(books))
+	for _, b := range books {
+		if b.Author == "" {
+			parts = append(parts, b.Title)
+			continue
+		}
+		parts = append(parts, fmt.Sprintf("%s by %s", b.Title, b.Author))
+	}
+	return "Books the user rated highly: " + strings.Join(parts, "; ") + ".", nil
+}
+
+// favoriteAuthors renders the top authors by affinity as a prompt fragment.
+func (r *Recommender) favoriteAuthors(ctx context.Context) (string, error) {
+	aff, err := r.authorAffinity(ctx)
+	if err != nil {
+		return "", err
+	}
+	if len(aff) == 0 {
+		return "", nil
+	}
+
+	var books []models.Book
+	if err := r.db.WithContext(ctx).
+		Where("shelf = ? AND user_rating > 0", models.ShelfRead).
+		Find(&books).Error; err != nil {
+		return "", fmt.Errorf("favorite authors: %w", err)
+	}
+	// Affinity keys are normalized for matching; recover a display spelling.
+	display := make(map[string]string, len(aff))
+	for _, b := range books {
+		if k := normalizeAuthor(b.Author); k != "" {
+			display[k] = strings.TrimSpace(b.Author)
+		}
+	}
+
+	type av struct {
+		a string
+		v float64
+	}
+	avs := make([]av, 0, len(aff))
+	for a, v := range aff {
+		if v <= 0 {
+			continue // only surface authors the user actually liked
+		}
+		avs = append(avs, av{a, v})
+	}
+	sort.Slice(avs, func(i, j int) bool {
+		if avs[i].v == avs[j].v {
+			return avs[i].a < avs[j].a
+		}
+		return avs[i].v > avs[j].v
+	})
+	if len(avs) > 5 {
+		avs = avs[:5]
+	}
+	if len(avs) == 0 {
+		return "", nil
+	}
+	names := make([]string, 0, len(avs))
+	for _, x := range avs {
+		name := display[x.a]
+		if name == "" {
+			name = x.a
+		}
+		names = append(names, name)
+	}
+	return "Favorite authors, most to least: " + strings.Join(names, ", ") + ".", nil
+}

--- a/lib/recommend/books.go
+++ b/lib/recommend/books.go
@@ -2,6 +2,7 @@ package recommend
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sort"
 	"strings"
@@ -39,13 +40,18 @@ func (s *goodreadsSource) Sync(ctx context.Context) (int, error) {
 	count := 0
 	for _, shelf := range []string{goodreads.ShelfRead, goodreads.ShelfToRead} {
 		books, err := s.client.Shelf(ctx, s.userID, shelf)
-		if err != nil {
+		switch {
+		case errors.Is(err, goodreads.ErrTruncated):
+			// A capped shelf still gives a usable pool; log rather than drop it.
+			l.Warnw("goodreads shelf truncated", "shelf", shelf, "books", len(books), zap.Error(err))
+		case err != nil:
 			// One unreachable shelf shouldn't discard the other.
 			l.Warnw("goodreads shelf fetch failed", "shelf", shelf, zap.Error(err))
 			continue
 		}
+		rows := make([]models.Book, 0, len(books))
 		for _, b := range books {
-			row := models.Book{
+			rows = append(rows, models.Book{
 				GoodreadsID: b.GoodreadsID,
 				Title:       b.Title,
 				Author:      b.Author,
@@ -60,14 +66,14 @@ func (s *goodreadsSource) Sync(ctx context.Context) (int, error) {
 				ReadAt:      b.ReadAt,
 				AddedAt:     b.AddedAt,
 				SyncedAt:    now,
-			}
-			if err := s.upsert(ctx, row); err != nil {
-				l.Warnw("upsert book failed", "goodreads_id", b.GoodreadsID, zap.Error(err))
-				continue
-			}
-			count++
+			})
 		}
-		l.Infow("goodreads shelf synced", "shelf", shelf, "books", len(books))
+		if err := s.upsert(ctx, rows); err != nil {
+			l.Warnw("goodreads shelf upsert failed", "shelf", shelf, zap.Error(err))
+			continue
+		}
+		count += len(rows)
+		l.Infow("goodreads shelf synced", "shelf", shelf, "books", len(rows))
 	}
 	if count == 0 {
 		return 0, fmt.Errorf("goodreads: no books synced for user %q", s.userID)
@@ -75,8 +81,16 @@ func (s *goodreadsSource) Sync(ctx context.Context) (int, error) {
 	return count, nil
 }
 
-// upsert inserts or refreshes one book on its Goodreads id.
-func (s *goodreadsSource) upsert(ctx context.Context, b models.Book) error {
+// upsertBatch caps rows per statement. Shelves run to thousands of books and
+// this sync shares a time-boxed cron lock with the Plex cache refresh, so
+// per-row round trips to Postgres would dominate the run.
+const upsertBatch = 200
+
+// upsert inserts or refreshes books on their Goodreads ids.
+func (s *goodreadsSource) upsert(ctx context.Context, books []models.Book) error {
+	if len(books) == 0 {
+		return nil
+	}
 	return s.db.WithContext(ctx).Clauses(clause.OnConflict{
 		Columns: []clause.Column{{Name: "goodreads_id"}},
 		DoUpdates: clause.AssignmentColumns([]string{
@@ -84,7 +98,7 @@ func (s *goodreadsSource) upsert(ctx context.Context, b models.Book) error {
 			"genre", "cover_url", "isbn", "pages", "read_at", "added_at",
 			"synced_at", "updated_at",
 		}),
-	}).Create(&b).Error
+	}).CreateInBatches(&books, upsertBatch).Error
 }
 
 // authorAffinity computes a normalized (0..1) taste weight per author from the

--- a/lib/recommend/books.go
+++ b/lib/recommend/books.go
@@ -16,12 +16,9 @@ import (
 )
 
 // goodreadsSource mirrors the user's Goodreads shelves into the books table.
-//
-// Unlike the other SignalSources, which write ExternalSignal rows to re-rank
-// owned Plex titles, this one owns its candidate pool: the to-read shelf *is*
-// the recommendable set, and the read shelf carries the taste signal in its star
-// ratings. Books therefore live in their own table rather than in ExternalSignal,
-// which can only join to a Movie or TVShow.
+// Unlike the other SignalSources, which only re-rank owned Plex titles, this one
+// owns its candidate pool. Books get their own table because ExternalSignal can
+// only join to a Movie or TVShow.
 type goodreadsSource struct {
 	db     *gorm.DB
 	client *goodreads.Client
@@ -30,13 +27,12 @@ type goodreadsSource struct {
 
 func (s *goodreadsSource) Name() string { return models.SourceGoodreads }
 
-// goodreadsRatingScale converts Goodreads' 0-5 stars to the 0-10 scale Movie and
-// TVShow ratings use, so book candidates score and render on the same axis.
+// goodreadsRatingScale maps Goodreads' 0-5 stars onto the 0-10 scale Movie and
+// TVShow use, so all three tiers score on one axis.
 const goodreadsRatingScale = 2.0
 
-// Sync refreshes both shelves. Shelf membership is refreshed on every run
-// because a book moves from to-read to read once finished, and a stale row would
-// keep recommending a book the user has already read.
+// Sync refreshes both shelves, including Shelf itself: a finished book moves from
+// to-read to read, and a stale row would keep recommending it.
 func (s *goodreadsSource) Sync(ctx context.Context) (int, error) {
 	l := logging.FromContext(ctx)
 	now := time.Now()
@@ -44,8 +40,7 @@ func (s *goodreadsSource) Sync(ctx context.Context) (int, error) {
 	for _, shelf := range []string{goodreads.ShelfRead, goodreads.ShelfToRead} {
 		books, err := s.client.Shelf(ctx, s.userID, shelf)
 		if err != nil {
-			// One unreachable shelf shouldn't discard the other: the to-read pool
-			// is still usable without a refreshed read shelf, and vice versa.
+			// One unreachable shelf shouldn't discard the other.
 			l.Warnw("goodreads shelf fetch failed", "shelf", shelf, zap.Error(err))
 			continue
 		}
@@ -93,12 +88,9 @@ func (s *goodreadsSource) upsert(ctx context.Context, b models.Book) error {
 }
 
 // authorAffinity computes a normalized (0..1) taste weight per author from the
-// read shelf's star ratings.
-//
-// Books get author affinity where movies and TV get genre affinity, because the
-// Goodreads feed carries no genre field — only the user's own shelf names, which
-// most accounts leave empty. An author the user rated highly is both available
-// and a stronger signal for books than a genre would be.
+// read shelf's star ratings. Books use author affinity where screen titles use
+// genre affinity: the feed has no genre field, only the user's own shelf names,
+// which most accounts leave empty.
 func (r *Recommender) authorAffinity(ctx context.Context) (map[string]float64, error) {
 	var read []models.Book
 	if err := r.db.WithContext(ctx).
@@ -107,8 +99,7 @@ func (r *Recommender) authorAffinity(ctx context.Context) (map[string]float64, e
 		return nil, fmt.Errorf("affinity books: %w", err)
 	}
 
-	// Center on 3 stars so a book the user actively disliked pushes its author
-	// down instead of merely failing to push them up.
+	// Centered on 3 stars, so a disliked book pushes its author down.
 	raw := make(map[string]float64)
 	for _, b := range read {
 		author := normalizeAuthor(b.Author)
@@ -190,9 +181,8 @@ func (r *Recommender) recentlyRecommendedBookIDs(ctx context.Context, date time.
 	return out, nil
 }
 
-// lovedBooks summarizes up to 5 of the user's highest-rated finished books for
-// prompt context. Titles and authors let the model reason about literary taste,
-// which the empty genre column cannot.
+// lovedBooks summarizes up to 5 highest-rated finished books for prompt context.
+// Titles and authors carry the literary taste the empty genre column cannot.
 func (r *Recommender) lovedBooks(ctx context.Context) (string, error) {
 	var books []models.Book
 	if err := r.db.WithContext(ctx).
@@ -231,7 +221,7 @@ func (r *Recommender) favoriteAuthors(ctx context.Context) (string, error) {
 		Find(&books).Error; err != nil {
 		return "", fmt.Errorf("favorite authors: %w", err)
 	}
-	// Affinity keys are normalized for matching; recover a display spelling.
+	// Affinity keys are normalized; recover a display spelling.
 	display := make(map[string]string, len(aff))
 	for _, b := range books {
 		if k := normalizeAuthor(b.Author); k != "" {
@@ -246,7 +236,7 @@ func (r *Recommender) favoriteAuthors(ctx context.Context) (string, error) {
 	avs := make([]av, 0, len(aff))
 	for a, v := range aff {
 		if v <= 0 {
-			continue // only surface authors the user actually liked
+			continue // only authors the user actually liked
 		}
 		avs = append(avs, av{a, v})
 	}

--- a/lib/recommend/books_test.go
+++ b/lib/recommend/books_test.go
@@ -310,3 +310,51 @@ func TestBookPromptFragments_emptyWithoutBooks(t *testing.T) {
 		t.Errorf("favoriteAuthors = %q, %v; want empty, nil", authors, err)
 	}
 }
+
+// Real shelves run to thousands of books, so the upsert must batch rather than
+// make a round trip per row.
+func TestGoodreadsSync_batchesLargeShelf(t *testing.T) {
+	db := bookDB(t)
+	const total = upsertBatch*2 + 37
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		page, body := r.URL.Query().Get("page"), ""
+		if r.URL.Query().Get("shelf") == goodreads.ShelfToRead && page == "1" {
+			var b strings.Builder
+			for i := range total {
+				b.WriteString(item(fmt.Sprint(i), fmt.Sprintf("Book %d", i), "An Author",
+					`<average_rating>4.00</average_rating>`))
+			}
+			body = b.String()
+		}
+		_, _ = fmt.Fprintf(w, `<rss version="2.0"><channel>%s</channel></rss>`, body)
+	}))
+	defer srv.Close()
+
+	src := &goodreadsSource{db: db, client: &goodreads.Client{URL: srv.URL}, userID: "12680"}
+	n, err := src.Sync(context.Background())
+	if err != nil {
+		t.Fatalf("Sync: %v", err)
+	}
+	if n != total {
+		t.Errorf("synced %d, want %d", n, total)
+	}
+	var count int64
+	if err := db.Model(&models.Book{}).Count(&count).Error; err != nil {
+		t.Fatalf("count: %v", err)
+	}
+	if count != total {
+		t.Errorf("stored %d rows, want %d across batches", count, total)
+	}
+
+	// A second sync must upsert, not duplicate.
+	if _, err := src.Sync(context.Background()); err != nil {
+		t.Fatalf("second Sync: %v", err)
+	}
+	if err := db.Model(&models.Book{}).Count(&count).Error; err != nil {
+		t.Fatalf("recount: %v", err)
+	}
+	if count != total {
+		t.Errorf("after re-sync got %d rows, want %d", count, total)
+	}
+}

--- a/lib/recommend/books_test.go
+++ b/lib/recommend/books_test.go
@@ -1,0 +1,312 @@
+package recommend
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/icco/recommender/lib/dbtest"
+	"github.com/icco/recommender/lib/goodreads"
+	"github.com/icco/recommender/models"
+	"gorm.io/gorm"
+)
+
+func bookDB(t *testing.T) *gorm.DB {
+	t.Helper()
+	db := dbtest.New(t)
+	if err := db.AutoMigrate(&models.Book{}, &models.Recommendation{}); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	return db
+}
+
+// shelfServer serves a per-shelf RSS feed keyed by the shelf query parameter.
+func shelfServer(t *testing.T, byShelf map[string]string) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body := ""
+		if r.URL.Query().Get("page") == "1" {
+			body = byShelf[r.URL.Query().Get("shelf")]
+		}
+		_, _ = fmt.Fprintf(w, `<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0"><channel>%s</channel></rss>`, body)
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func item(id, title, author, shelfExtra string) string {
+	return fmt.Sprintf(`<item>
+    <title><![CDATA[%s]]></title>
+    <book_id>%s</book_id>
+    <author_name>%s</author_name>
+    <book id="%s"><num_pages>300</num_pages></book>
+    %s
+  </item>`, title, id, author, id, shelfExtra)
+}
+
+func TestGoodreadsSync_storesBothShelvesWithRescaledRating(t *testing.T) {
+	db := bookDB(t)
+	srv := shelfServer(t, map[string]string{
+		goodreads.ShelfRead: item("1", "A Wizard of Earthsea", "Ursula K. Le Guin",
+			`<user_rating>5</user_rating><average_rating>4.03</average_rating><book_published>1968</book_published>`),
+		goodreads.ShelfToRead: item("2", "Goodbye Chinatown", "Kit Fan",
+			`<user_rating>0</user_rating><average_rating>3.50</average_rating>`),
+	})
+
+	src := &goodreadsSource{db: db, client: &goodreads.Client{URL: srv.URL}, userID: "12680"}
+	n, err := src.Sync(context.Background())
+	if err != nil {
+		t.Fatalf("Sync: %v", err)
+	}
+	if n != 2 {
+		t.Fatalf("synced %d books, want 2", n)
+	}
+
+	var read models.Book
+	if err := db.Where("goodreads_id = ?", "1").First(&read).Error; err != nil {
+		t.Fatalf("load read book: %v", err)
+	}
+	if read.Shelf != models.ShelfRead {
+		t.Errorf("Shelf = %q, want read", read.Shelf)
+	}
+	if read.UserRating != 5 {
+		t.Errorf("UserRating = %d, want 5", read.UserRating)
+	}
+	// Stored on the 0-10 scale shared with movies and TV.
+	if read.Rating != 8.06 {
+		t.Errorf("Rating = %v, want 8.06 (4.03 rescaled)", read.Rating)
+	}
+	if read.Pages != 300 {
+		t.Errorf("Pages = %d, want 300", read.Pages)
+	}
+
+	var toRead models.Book
+	if err := db.Where("goodreads_id = ?", "2").First(&toRead).Error; err != nil {
+		t.Fatalf("load to-read book: %v", err)
+	}
+	if toRead.Shelf != models.ShelfToRead {
+		t.Errorf("Shelf = %q, want to-read", toRead.Shelf)
+	}
+}
+
+// A finished book moves shelves. The upsert must follow it, or the book stays in
+// the candidate pool forever.
+func TestGoodreadsSync_movesBookBetweenShelves(t *testing.T) {
+	db := bookDB(t)
+	body := item("1", "Piranesi", "Susanna Clarke", `<average_rating>4.20</average_rating>`)
+
+	srv := shelfServer(t, map[string]string{goodreads.ShelfToRead: body})
+	src := &goodreadsSource{db: db, client: &goodreads.Client{URL: srv.URL}, userID: "12680"}
+	if _, err := src.Sync(context.Background()); err != nil {
+		t.Fatalf("first Sync: %v", err)
+	}
+
+	moved := shelfServer(t, map[string]string{
+		goodreads.ShelfRead: item("1", "Piranesi", "Susanna Clarke",
+			`<user_rating>5</user_rating><average_rating>4.20</average_rating>`),
+	})
+	src.client = &goodreads.Client{URL: moved.URL}
+	if _, err := src.Sync(context.Background()); err != nil {
+		t.Fatalf("second Sync: %v", err)
+	}
+
+	var count int64
+	if err := db.Model(&models.Book{}).Count(&count).Error; err != nil {
+		t.Fatalf("count: %v", err)
+	}
+	if count != 1 {
+		t.Errorf("got %d rows, want 1 upserted", count)
+	}
+	var b models.Book
+	if err := db.Where("goodreads_id = ?", "1").First(&b).Error; err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if b.Shelf != models.ShelfRead {
+		t.Errorf("Shelf = %q, want read after the move", b.Shelf)
+	}
+	if b.UserRating != 5 {
+		t.Errorf("UserRating = %d, want 5", b.UserRating)
+	}
+}
+
+// One unreachable shelf must not discard the other.
+func TestGoodreadsSync_partialShelfFailure(t *testing.T) {
+	db := bookDB(t)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Query().Get("shelf") == goodreads.ShelfRead {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		body := ""
+		if r.URL.Query().Get("page") == "1" {
+			body = item("2", "Babel", "R.F. Kuang", `<average_rating>4.10</average_rating>`)
+		}
+		_, _ = fmt.Fprintf(w, `<rss version="2.0"><channel>%s</channel></rss>`, body)
+	}))
+	defer srv.Close()
+
+	src := &goodreadsSource{db: db, client: &goodreads.Client{URL: srv.URL}, userID: "12680"}
+	n, err := src.Sync(context.Background())
+	if err != nil {
+		t.Fatalf("Sync: %v", err)
+	}
+	if n != 1 {
+		t.Errorf("synced %d, want the one reachable shelf", n)
+	}
+}
+
+// A user id that resolves to nothing must error rather than silently emptying
+// the pool.
+func TestGoodreadsSync_errorsWhenNothingSynced(t *testing.T) {
+	db := bookDB(t)
+	srv := shelfServer(t, map[string]string{})
+	src := &goodreadsSource{db: db, client: &goodreads.Client{URL: srv.URL}, userID: "99999"}
+	if _, err := src.Sync(context.Background()); err == nil {
+		t.Fatal("Sync: want error when no books synced, got nil")
+	}
+}
+
+func seedBooks(t *testing.T, db *gorm.DB, books ...models.Book) {
+	t.Helper()
+	for i := range books {
+		if books[i].GoodreadsID == "" {
+			books[i].GoodreadsID = fmt.Sprintf("gr-%d-%s", i, books[i].Title)
+		}
+		if err := db.Create(&books[i]).Error; err != nil {
+			t.Fatalf("seed %q: %v", books[i].Title, err)
+		}
+	}
+}
+
+func TestAuthorAffinity_centersOnThreeStars(t *testing.T) {
+	db := bookDB(t)
+	seedBooks(t, db,
+		models.Book{Title: "Earthsea", Author: "Ursula K. Le Guin", Shelf: models.ShelfRead, UserRating: 5},
+		models.Book{Title: "Lathe of Heaven", Author: "Ursula K. Le Guin", Shelf: models.ShelfRead, UserRating: 5},
+		models.Book{Title: "Meh", Author: "Middling Author", Shelf: models.ShelfRead, UserRating: 3},
+		models.Book{Title: "Bad", Author: "Disliked Author", Shelf: models.ShelfRead, UserRating: 1},
+		// Unrated and to-read rows contribute nothing.
+		models.Book{Title: "Unrated", Author: "Unknown", Shelf: models.ShelfRead, UserRating: 0},
+		models.Book{Title: "Queued", Author: "Queued Author", Shelf: models.ShelfToRead},
+	)
+
+	r := &Recommender{db: db}
+	aff, err := r.authorAffinity(context.Background())
+	if err != nil {
+		t.Fatalf("authorAffinity: %v", err)
+	}
+	if got := aff["ursula k. le guin"]; got != 1.0 {
+		t.Errorf("Le Guin affinity = %v, want 1.0 (the peak)", got)
+	}
+	if got := aff["middling author"]; got != 0 {
+		t.Errorf("3-star author affinity = %v, want 0", got)
+	}
+	if got := aff["disliked author"]; got >= 0 {
+		t.Errorf("1-star author affinity = %v, want negative", got)
+	}
+	if _, ok := aff["queued author"]; ok {
+		t.Error("to-read author should not contribute affinity")
+	}
+	if _, ok := aff["unknown"]; ok {
+		t.Error("unrated book should not contribute affinity")
+	}
+}
+
+func TestLoadBookCandidates_toReadOnlyAndExcludesRecent(t *testing.T) {
+	db := bookDB(t)
+	seedBooks(t, db,
+		models.Book{Title: "Fresh Pick", Author: "Ursula K. Le Guin", Shelf: models.ShelfToRead, Rating: 8.0, Pages: 300},
+		models.Book{Title: "Recently Recommended", Author: "Someone", Shelf: models.ShelfToRead, Rating: 9.0},
+		models.Book{Title: "Already Read", Author: "Ursula K. Le Guin", Shelf: models.ShelfRead, UserRating: 5},
+	)
+
+	var recent models.Book
+	if err := db.Where("title = ?", "Recently Recommended").First(&recent).Error; err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	date := time.Date(2026, 8, 2, 0, 0, 0, 0, time.UTC)
+	if err := db.Create(&models.Recommendation{
+		Date: date.AddDate(0, 0, -3), Title: "Recently Recommended", Type: models.TypeBook,
+		BookID: &recent.ID,
+	}).Error; err != nil {
+		t.Fatalf("seed recommendation: %v", err)
+	}
+
+	r := &Recommender{db: db}
+	cands, err := r.loadBookCandidates(context.Background(), date, 30)
+	if err != nil {
+		t.Fatalf("loadBookCandidates: %v", err)
+	}
+	if len(cands) != 1 {
+		t.Fatalf("got %d candidates, want 1: %+v", len(cands), cands)
+	}
+	c := cands[0]
+	if c.Title != "Fresh Pick" {
+		t.Errorf("Title = %q, want Fresh Pick", c.Title)
+	}
+	if c.Type != models.TypeBook {
+		t.Errorf("Type = %q, want book", c.Type)
+	}
+	if c.Runtime != 300 {
+		t.Errorf("Runtime = %d, want the page count 300", c.Runtime)
+	}
+	// The Le Guin read-shelf 5-star rating is the pool's only signal, so it peaks.
+	if c.Affinity != 1.0 {
+		t.Errorf("Affinity = %v, want 1.0 from the read-shelf rating", c.Affinity)
+	}
+	if !strings.Contains(c.SourceURL, "goodreads.com/book/show/") {
+		t.Errorf("SourceURL = %q, want a goodreads book link", c.SourceURL)
+	}
+}
+
+func TestLovedBooksAndFavoriteAuthors(t *testing.T) {
+	db := bookDB(t)
+	seedBooks(t, db,
+		models.Book{Title: "Earthsea", Author: "Ursula K. Le Guin", Shelf: models.ShelfRead, UserRating: 5},
+		models.Book{Title: "Fine", Author: "Okay Author", Shelf: models.ShelfRead, UserRating: 3},
+	)
+
+	r := &Recommender{db: db}
+	loved, err := r.lovedBooks(context.Background())
+	if err != nil {
+		t.Fatalf("lovedBooks: %v", err)
+	}
+	if !strings.Contains(loved, "Earthsea by Ursula K. Le Guin") {
+		t.Errorf("lovedBooks = %q, want the 5-star book with its author", loved)
+	}
+	if strings.Contains(loved, "Fine") {
+		t.Errorf("lovedBooks = %q, should omit the 3-star book", loved)
+	}
+
+	authors, err := r.favoriteAuthors(context.Background())
+	if err != nil {
+		t.Fatalf("favoriteAuthors: %v", err)
+	}
+	// Display spelling, not the normalized affinity key.
+	if !strings.Contains(authors, "Ursula K. Le Guin") {
+		t.Errorf("favoriteAuthors = %q, want the display spelling", authors)
+	}
+	if strings.Contains(authors, "Okay Author") {
+		t.Errorf("favoriteAuthors = %q, should omit the neutral author", authors)
+	}
+}
+
+// With no books at all, both prompt fragments are empty rather than erroring, so
+// the run proceeds without a books tier.
+func TestBookPromptFragments_emptyWithoutBooks(t *testing.T) {
+	db := bookDB(t)
+	r := &Recommender{db: db}
+	loved, err := r.lovedBooks(context.Background())
+	if err != nil || loved != "" {
+		t.Errorf("lovedBooks = %q, %v; want empty, nil", loved, err)
+	}
+	authors, err := r.favoriteAuthors(context.Background())
+	if err != nil || authors != "" {
+		t.Errorf("favoriteAuthors = %q, %v; want empty, nil", authors, err)
+	}
+}

--- a/lib/recommend/candidates.go
+++ b/lib/recommend/candidates.go
@@ -12,7 +12,7 @@ import (
 )
 
 // candidate is a title eligible for recommendation, with a computed score.
-// Movies and TV shows are Plex-owned; books come from the Goodreads to-read shelf.
+// Movies and TV are Plex-owned; books come from the Goodreads to-read shelf.
 type candidate struct {
 	ID          uint
 	Type        string
@@ -24,7 +24,7 @@ type candidate struct {
 	Runtime     int // minutes (movie), seasons (tv), or pages (book)
 	ViewCount   int
 	TMDbID      *int
-	Affinity    float64 // taste-profile boost: genre affinity for screen titles, author affinity for books
+	Affinity    float64 // genre affinity for screen titles, author affinity for books
 	Watchlisted bool    // present on an external watchlist (Trakt)
 	Metascore   *int    // Metacritic critic score 0-100; nil when unknown
 	Author      string  // books only
@@ -115,10 +115,9 @@ func formatShortlist(cands []candidate) string {
 	return b.String()
 }
 
-// formatBookShortlist renders book candidates for the prompt. Books get their own
-// line format because the fields that matter differ from screen titles: author
-// instead of genre (the Goodreads feed has no genres), page count instead of
-// runtime, and no watched state — every book here is unread by definition.
+// formatBookShortlist renders book candidates for the prompt. Books need their own
+// line format: author instead of genre, pages instead of runtime, and no watched
+// state — every book here is unread by definition.
 func formatBookShortlist(cands []candidate) string {
 	var b strings.Builder
 	for _, c := range cands {
@@ -126,13 +125,12 @@ func formatBookShortlist(cands []candidate) string {
 		if author == "" {
 			author = "unknown author"
 		}
-		// Year is often absent on to-read entries, so omit it rather than print 0.
+		// Year is often absent on to-read entries; omit rather than print 0.
 		year := ""
 		if c.Year > 0 {
 			year = fmt.Sprintf(" (%d)", c.Year)
 		}
-		// Back to Goodreads' native 5-star scale, which is how the number reads
-		// everywhere the user has seen it.
+		// Back to the native 5-star scale the user recognizes.
 		rating := ""
 		if c.Rating > 0 {
 			rating = fmt.Sprintf(" — Goodreads: %.2f/5", c.Rating/goodreadsRatingScale)

--- a/lib/recommend/candidates.go
+++ b/lib/recommend/candidates.go
@@ -11,7 +11,8 @@ import (
 	"github.com/icco/recommender/models"
 )
 
-// candidate is a Plex-owned title eligible for recommendation, with a computed score.
+// candidate is a title eligible for recommendation, with a computed score.
+// Movies and TV shows are Plex-owned; books come from the Goodreads to-read shelf.
 type candidate struct {
 	ID          uint
 	Type        string
@@ -20,12 +21,14 @@ type candidate struct {
 	Rating      float64
 	Genres      []string
 	PosterURL   string
-	Runtime     int // minutes (movie) or seasons (tv)
+	Runtime     int // minutes (movie), seasons (tv), or pages (book)
 	ViewCount   int
 	TMDbID      *int
-	Affinity    float64 // taste-profile boost (Phase 2); 0 otherwise
+	Affinity    float64 // taste-profile boost: genre affinity for screen titles, author affinity for books
 	Watchlisted bool    // present on an external watchlist (Trakt)
 	Metascore   *int    // Metacritic critic score 0-100; nil when unknown
+	Author      string  // books only
+	SourceURL   string  // canonical page for the title (goodreads.com for books)
 }
 
 // dateSeed derives a stable per-UTC-day seed so shortlists are reproducible.
@@ -108,6 +111,42 @@ func formatShortlist(cands []candidate) string {
 		}
 		fmt.Fprintf(&b, "[id=%d] %s (%d) — Rating: %.1f%s — Genres: %s — %s\n",
 			c.ID, c.Title, c.Year, c.Rating, metacritic, strings.Join(c.Genres, ", "), watched)
+	}
+	return b.String()
+}
+
+// formatBookShortlist renders book candidates for the prompt. Books get their own
+// line format because the fields that matter differ from screen titles: author
+// instead of genre (the Goodreads feed has no genres), page count instead of
+// runtime, and no watched state — every book here is unread by definition.
+func formatBookShortlist(cands []candidate) string {
+	var b strings.Builder
+	for _, c := range cands {
+		author := c.Author
+		if author == "" {
+			author = "unknown author"
+		}
+		// Year is often absent on to-read entries, so omit it rather than print 0.
+		year := ""
+		if c.Year > 0 {
+			year = fmt.Sprintf(" (%d)", c.Year)
+		}
+		// Back to Goodreads' native 5-star scale, which is how the number reads
+		// everywhere the user has seen it.
+		rating := ""
+		if c.Rating > 0 {
+			rating = fmt.Sprintf(" — Goodreads: %.2f/5", c.Rating/goodreadsRatingScale)
+		}
+		pages := ""
+		if c.Runtime > 0 {
+			pages = fmt.Sprintf(" — %d pages", c.Runtime)
+		}
+		shelves := ""
+		if len(c.Genres) > 0 {
+			shelves = " — Shelves: " + strings.Join(c.Genres, ", ")
+		}
+		fmt.Fprintf(&b, "[id=%d] %s by %s%s%s%s%s\n",
+			c.ID, c.Title, author, year, rating, pages, shelves)
 	}
 	return b.String()
 }

--- a/lib/recommend/generate.go
+++ b/lib/recommend/generate.go
@@ -23,8 +23,7 @@ const (
 	targetTVShows = 3
 	targetBooks   = 3
 
-	// recentExclusionDays keeps a title out of the pool for this many days after
-	// it was last recommended.
+	// recentExclusionDays keeps a title out of the pool after being recommended.
 	recentExclusionDays = 30
 )
 
@@ -61,9 +60,7 @@ func (r *Recommender) GenerateRecommendations(ctx context.Context, date time.Tim
 	if err != nil {
 		return r.recordRun(ctx, date, counts{}, err)
 	}
-	// Books are optional: the tier stays empty unless GOODREADS_USER_ID is set and
-	// a shelf sync has run, and an unreachable Goodreads must not sink the day's
-	// movie and TV recommendations.
+	// Books are optional; a Goodreads problem must not sink movies and TV.
 	books, err := r.loadBookCandidates(ctx, date, recentExclusionDays)
 	if err != nil {
 		l.Warnw("book candidates failed; continuing without books", zap.Error(err))
@@ -129,8 +126,8 @@ type counts struct {
 	books   int
 }
 
-// tally counts recommendations by tier. It switches on Type explicitly rather
-// than treating "not a movie" as TV, which would silently file books as TV shows.
+// tally counts by tier. Switching on Type explicitly matters: treating
+// "not a movie" as TV would file books as TV shows.
 func tally(recs []models.Recommendation) counts {
 	var c counts
 	for _, rec := range recs {
@@ -169,8 +166,6 @@ func (r *Recommender) renderPrompts(ctx context.Context, movies, tvshows, books 
 		logging.FromContext(ctx).Warnw("loved titles failed; continuing without", zap.Error(err))
 		loved = ""
 	}
-	// Book taste context is best-effort for the same reason the book pool is:
-	// a Goodreads problem should cost the books tier, not the whole run.
 	authors, err := r.favoriteAuthors(ctx)
 	if err != nil {
 		logging.FromContext(ctx).Warnw("favorite authors failed; continuing without", zap.Error(err))
@@ -183,8 +178,7 @@ func (r *Recommender) renderPrompts(ctx context.Context, movies, tvshows, books 
 	}
 	var b strings.Builder
 	if err := userTmpl.Execute(&b, promptData{
-		// TargetBooks collapses to 0 with an empty shelf, which drops the books
-		// section from the prompt rather than asking for picks from nothing.
+		// TargetBooks of 0 drops the books section from the prompt entirely.
 		TargetMovies: targetMovies, TargetTVShows: targetTVShows, TargetBooks: min(len(books), targetBooks),
 		Profile: profile, Loved: loved, Authors: authors, LovedBooks: lovedBooks,
 		Movies: formatShortlist(movies), TVShows: formatShortlist(tvshows),
@@ -200,10 +194,9 @@ func (r *Recommender) renderPrompts(ctx context.Context, movies, tvshows, books 
 // URLs point at a private, token-gated host browsers can't reach. Bounded to the
 // finalist set, so at most a handful of downloads per run.
 //
-// Books are skipped: Goodreads cover URLs are already public on i.gr-assets.com,
-// so the browser loads them directly. Routing them through the Plex downloader
-// would fetch every cover only to have the host check reject it, logging a
-// warning per book.
+// Books are skipped: Goodreads covers are already public, so the browser loads
+// them directly. The Plex downloader's host check would reject each one anyway,
+// logging a warning per book.
 func (r *Recommender) cachePoster(ctx context.Context, rec *models.Recommendation) {
 	if r.posterDir == "" || rec.PosterURL == "" || r.plex == nil || rec.Type == models.TypeBook {
 		return
@@ -233,10 +226,9 @@ func (r *Recommender) saveRecommendations(ctx context.Context, date time.Time, r
 		if err := tx.Where(`"date" = ?`, date).Delete(&models.Recommendation{}).Error; err != nil {
 			return fmt.Errorf("clear existing recs: %w", err)
 		}
-		// The (date, type, title) unique index rejects two items of the same type
-		// sharing a title on one day; skip in-batch collisions rather than fail the
-		// run. Type is part of the key so a book and a film of the same name — Dune,
-		// say — can both appear.
+		// The (date, type, title) index rejects same-type title collisions on one
+		// day; skip them rather than fail the run. Type is in the key so a book and
+		// a film named Dune can both appear.
 		type key struct{ recType, title string }
 		seen := make(map[key]bool, len(recs))
 		for i := range recs {

--- a/lib/recommend/generate.go
+++ b/lib/recommend/generate.go
@@ -21,15 +21,24 @@ const (
 	shortlistSize = 80
 	targetMovies  = 4
 	targetTVShows = 3
+	targetBooks   = 3
+
+	// recentExclusionDays keeps a title out of the pool for this many days after
+	// it was last recommended.
+	recentExclusionDays = 30
 )
 
 type promptData struct {
 	TargetMovies  int
 	TargetTVShows int
+	TargetBooks   int
 	Profile       string
 	Loved         string
+	Authors       string
+	LovedBooks    string
 	Movies        string
 	TVShows       string
+	Books         string
 }
 
 // GenerateRecommendations builds the day's recommendations from the cached Plex
@@ -50,37 +59,48 @@ func (r *Recommender) GenerateRecommendations(ctx context.Context, date time.Tim
 
 	movies, tvshows, err := r.loadCandidates(ctx, date)
 	if err != nil {
-		return r.recordRun(ctx, date, 0, 0, err)
+		return r.recordRun(ctx, date, counts{}, err)
 	}
-	if len(movies) == 0 && len(tvshows) == 0 {
+	// Books are optional: the tier stays empty unless GOODREADS_USER_ID is set and
+	// a shelf sync has run, and an unreachable Goodreads must not sink the day's
+	// movie and TV recommendations.
+	books, err := r.loadBookCandidates(ctx, date, recentExclusionDays)
+	if err != nil {
+		l.Warnw("book candidates failed; continuing without books", zap.Error(err))
+		books = nil
+	}
+	if len(movies) == 0 && len(tvshows) == 0 && len(books) == 0 {
 		err := fmt.Errorf("no eligible candidates; run /cron/cache first")
-		return r.recordRun(ctx, date, 0, 0, err)
+		return r.recordRun(ctx, date, counts{}, err)
 	}
 
 	movieShortlist := buildShortlist(movies, date, poolSize, shortlistSize)
 	tvShortlist := buildShortlist(tvshows, date, poolSize, shortlistSize)
+	bookShortlist := buildShortlist(books, date, poolSize, shortlistSize)
 
-	system, user, err := r.renderPrompts(ctx, movieShortlist, tvShortlist)
+	system, user, err := r.renderPrompts(ctx, movieShortlist, tvShortlist, bookShortlist)
 	if err != nil {
-		return r.recordRun(ctx, date, 0, 0, err)
+		return r.recordRun(ctx, date, counts{}, err)
 	}
 
 	raw, err := r.chat.Complete(ctx, system, user, pickSchema())
 	if err != nil {
-		return r.recordRun(ctx, date, 0, 0, fmt.Errorf("gemini: %w", err))
+		return r.recordRun(ctx, date, counts{}, fmt.Errorf("gemini: %w", err))
 	}
 
 	pr, err := parsePickResponse(raw)
 	if err != nil {
-		return r.recordRun(ctx, date, 0, 0, err)
+		return r.recordRun(ctx, date, counts{}, err)
 	}
 
 	combined := append([]candidate{}, movieShortlist...)
 	combined = append(combined, tvShortlist...)
+	combined = append(combined, bookShortlist...)
 	recs := selectMovies(pr.Movies, combined, targetMovies)
 	recs = append(recs, selectTVShows(pr.TVShows, combined, targetTVShows)...)
+	recs = append(recs, selectBooks(pr.Books, combined, targetBooks)...)
 	if len(recs) == 0 {
-		return r.recordRun(ctx, date, 0, 0, fmt.Errorf("no recommendations selected"))
+		return r.recordRun(ctx, date, counts{}, fmt.Errorf("no recommendations selected"))
 	}
 
 	for i := range recs {
@@ -88,27 +108,45 @@ func (r *Recommender) GenerateRecommendations(ctx context.Context, date time.Tim
 		r.cachePoster(ctx, &recs[i])
 	}
 
-	movieCount, tvCount := 0, 0
-	for _, rec := range recs {
-		if rec.Type == models.TypeMovie {
-			movieCount++
-		} else {
-			tvCount++
-		}
-	}
+	c := tally(recs)
 
 	if err := r.saveRecommendations(ctx, date, recs); err != nil {
-		return r.recordRun(ctx, date, movieCount, tvCount, err)
+		return r.recordRun(ctx, date, c, err)
 	}
 
-	if err := r.recordRun(ctx, date, movieCount, tvCount, nil); err != nil {
+	if err := r.recordRun(ctx, date, c, nil); err != nil {
 		return err
 	}
-	l.Infow("Generated recommendations", "movies", movieCount, "tvshows", tvCount, "duration", time.Since(start))
+	l.Infow("Generated recommendations", "movies", c.movies, "tvshows", c.tvshows,
+		"books", c.books, "duration", time.Since(start))
 	return nil
 }
 
-func (r *Recommender) renderPrompts(ctx context.Context, movies, tvshows []candidate) (system, user string, err error) {
+// counts is the per-tier tally recorded on a GenerationRun.
+type counts struct {
+	movies  int
+	tvshows int
+	books   int
+}
+
+// tally counts recommendations by tier. It switches on Type explicitly rather
+// than treating "not a movie" as TV, which would silently file books as TV shows.
+func tally(recs []models.Recommendation) counts {
+	var c counts
+	for _, rec := range recs {
+		switch rec.Type {
+		case models.TypeMovie:
+			c.movies++
+		case models.TypeTVShow:
+			c.tvshows++
+		case models.TypeBook:
+			c.books++
+		}
+	}
+	return c
+}
+
+func (r *Recommender) renderPrompts(ctx context.Context, movies, tvshows, books []candidate) (system, user string, err error) {
 	sysTmpl, err := prompts.FS.ReadFile("system.txt")
 	if err != nil {
 		return "", "", fmt.Errorf("read system prompt: %w", err)
@@ -131,10 +169,26 @@ func (r *Recommender) renderPrompts(ctx context.Context, movies, tvshows []candi
 		logging.FromContext(ctx).Warnw("loved titles failed; continuing without", zap.Error(err))
 		loved = ""
 	}
+	// Book taste context is best-effort for the same reason the book pool is:
+	// a Goodreads problem should cost the books tier, not the whole run.
+	authors, err := r.favoriteAuthors(ctx)
+	if err != nil {
+		logging.FromContext(ctx).Warnw("favorite authors failed; continuing without", zap.Error(err))
+		authors = ""
+	}
+	lovedBooks, err := r.lovedBooks(ctx)
+	if err != nil {
+		logging.FromContext(ctx).Warnw("loved books failed; continuing without", zap.Error(err))
+		lovedBooks = ""
+	}
 	var b strings.Builder
 	if err := userTmpl.Execute(&b, promptData{
-		TargetMovies: targetMovies, TargetTVShows: targetTVShows, Profile: profile, Loved: loved,
+		// TargetBooks collapses to 0 with an empty shelf, which drops the books
+		// section from the prompt rather than asking for picks from nothing.
+		TargetMovies: targetMovies, TargetTVShows: targetTVShows, TargetBooks: min(len(books), targetBooks),
+		Profile: profile, Loved: loved, Authors: authors, LovedBooks: lovedBooks,
 		Movies: formatShortlist(movies), TVShows: formatShortlist(tvshows),
+		Books: formatBookShortlist(books),
 	}); err != nil {
 		return "", "", fmt.Errorf("execute user prompt: %w", err)
 	}
@@ -145,8 +199,13 @@ func (r *Recommender) renderPrompts(ctx context.Context, movies, tvshows []candi
 // rewrites PosterURL to a public /posters/ path the web page can load. Plex thumb
 // URLs point at a private, token-gated host browsers can't reach. Bounded to the
 // finalist set, so at most a handful of downloads per run.
+//
+// Books are skipped: Goodreads cover URLs are already public on i.gr-assets.com,
+// so the browser loads them directly. Routing them through the Plex downloader
+// would fetch every cover only to have the host check reject it, logging a
+// warning per book.
 func (r *Recommender) cachePoster(ctx context.Context, rec *models.Recommendation) {
-	if r.posterDir == "" || rec.PosterURL == "" || r.plex == nil {
+	if r.posterDir == "" || rec.PosterURL == "" || r.plex == nil || rec.Type == models.TypeBook {
 		return
 	}
 	name := fmt.Sprintf("%s-%d.jpg", rec.Type, posterID(rec))
@@ -174,14 +233,18 @@ func (r *Recommender) saveRecommendations(ctx context.Context, date time.Time, r
 		if err := tx.Where(`"date" = ?`, date).Delete(&models.Recommendation{}).Error; err != nil {
 			return fmt.Errorf("clear existing recs: %w", err)
 		}
-		// The (date, title) unique index rejects two Plex items with the same title
-		// on one day; skip in-batch title collisions rather than fail the run.
-		seen := make(map[string]bool, len(recs))
+		// The (date, type, title) unique index rejects two items of the same type
+		// sharing a title on one day; skip in-batch collisions rather than fail the
+		// run. Type is part of the key so a book and a film of the same name — Dune,
+		// say — can both appear.
+		type key struct{ recType, title string }
+		seen := make(map[key]bool, len(recs))
 		for i := range recs {
-			if seen[recs[i].Title] {
+			k := key{recs[i].Type, recs[i].Title}
+			if seen[k] {
 				continue
 			}
-			seen[recs[i].Title] = true
+			seen[k] = true
 			if err := tx.Create(&recs[i]).Error; err != nil {
 				return fmt.Errorf("create rec %q: %w", recs[i].Title, err)
 			}
@@ -190,10 +253,10 @@ func (r *Recommender) saveRecommendations(ctx context.Context, date time.Time, r
 	})
 }
 
-func (r *Recommender) recordRun(ctx context.Context, date time.Time, movieCount, tvCount int, genErr error) error {
+func (r *Recommender) recordRun(ctx context.Context, date time.Time, c counts, genErr error) error {
 	run := models.GenerationRun{
-		Date: date, Status: models.RunStatusOK, MovieCount: movieCount,
-		TVShowCount: tvCount, Model: r.model,
+		Date: date, Status: models.RunStatusOK, MovieCount: c.movies,
+		TVShowCount: c.tvshows, BookCount: c.books, Model: r.model,
 	}
 	if genErr != nil {
 		run.Status = models.RunStatusError

--- a/lib/recommend/generate_test.go
+++ b/lib/recommend/generate_test.go
@@ -75,3 +75,95 @@ func TestGenerateRecommendations_endToEnd(t *testing.T) {
 		t.Fatalf("rerun changed rec count to %d", len(recs2))
 	}
 }
+
+func TestGenerateRecommendations_includesBookTier(t *testing.T) {
+	db := testDB(t)
+	ctx := context.Background()
+	date := time.Date(2026, 8, 2, 0, 0, 0, 0, time.UTC)
+
+	movie := models.Movie{Title: "Funny", Year: 2000, Rating: 8, Genre: "Comedy", PlexRatingKey: "m1"}
+	if err := db.Create(&movie).Error; err != nil {
+		t.Fatal(err)
+	}
+	// Same title as the movie, to prove (date, type, title) keeps both.
+	book := models.Book{GoodreadsID: "gr1", Title: "Funny", Author: "Susanna Clarke",
+		Shelf: models.ShelfToRead, Rating: 8.4, Pages: 245}
+	if err := db.Create(&book).Error; err != nil {
+		t.Fatal(err)
+	}
+
+	reply := fmt.Sprintf(`{"movies":[{"id":%d,"explanation":"lol"}],"tvshows":[],"books":[{"id":%d,"explanation":"strange and lovely"}]}`,
+		movie.ID, book.ID)
+	r := &Recommender{db: db, chat: fakeChatter{reply: reply}, model: "test"}
+
+	if err := r.GenerateRecommendations(ctx, date); err != nil {
+		t.Fatalf("generate: %v", err)
+	}
+
+	recs, err := r.GetRecommendationsForDate(ctx, date)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(recs) != 2 {
+		t.Fatalf("got %d recs, want a movie and a book sharing the title", len(recs))
+	}
+
+	var bookRec *models.Recommendation
+	for i := range recs {
+		if recs[i].Type == models.TypeBook {
+			bookRec = &recs[i]
+		}
+	}
+	if bookRec == nil {
+		t.Fatal("no book recommendation stored")
+	}
+	if bookRec.BookID == nil || *bookRec.BookID != book.ID {
+		t.Errorf("BookID = %v, want %d", bookRec.BookID, book.ID)
+	}
+	if bookRec.Author != "Susanna Clarke" {
+		t.Errorf("Author = %q, want Susanna Clarke", bookRec.Author)
+	}
+	if bookRec.Runtime != 245 {
+		t.Errorf("Runtime = %d, want the page count 245", bookRec.Runtime)
+	}
+	if bookRec.Explanation != "strange and lovely" {
+		t.Errorf("Explanation = %q", bookRec.Explanation)
+	}
+	if got := bookRec.GoodreadsRating(); got != 4.2 {
+		t.Errorf("GoodreadsRating = %v, want 4.2", got)
+	}
+
+	var run models.GenerationRun
+	if err := db.Where("status = ?", models.RunStatusOK).First(&run).Error; err != nil {
+		t.Fatalf("load run: %v", err)
+	}
+	if run.BookCount != 1 || run.MovieCount != 1 || run.TVShowCount != 0 {
+		t.Errorf("counts = movies %d, tv %d, books %d; want 1, 0, 1",
+			run.MovieCount, run.TVShowCount, run.BookCount)
+	}
+}
+
+// With no books shelved, the run still produces the screen tiers.
+func TestGenerateRecommendations_withoutBooks(t *testing.T) {
+	db := testDB(t)
+	ctx := context.Background()
+	date := time.Date(2026, 8, 3, 0, 0, 0, 0, time.UTC)
+
+	movie := models.Movie{Title: "Solo", Year: 2000, Rating: 8, Genre: "Comedy", PlexRatingKey: "m1"}
+	if err := db.Create(&movie).Error; err != nil {
+		t.Fatal(err)
+	}
+
+	reply := fmt.Sprintf(`{"movies":[{"id":%d,"explanation":"lol"}],"tvshows":[],"books":[]}`, movie.ID)
+	r := &Recommender{db: db, chat: fakeChatter{reply: reply}, model: "test"}
+	if err := r.GenerateRecommendations(ctx, date); err != nil {
+		t.Fatalf("generate: %v", err)
+	}
+	recs, err := r.GetRecommendationsForDate(ctx, date)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(recs) != 1 || recs[0].Type != models.TypeMovie {
+		t.Fatalf("got %+v, want just the movie", recs)
+	}
+}

--- a/lib/recommend/prompts/recommendation.txt
+++ b/lib/recommend/prompts/recommendation.txt
@@ -1,19 +1,29 @@
-Pick recommendations for the user from ONLY the shortlist below, using the id values.
+Pick recommendations for the user from ONLY the shortlists below, using the id values.
 
 Movies: choose up to {{.TargetMovies}} — ideally one comedy, one action/drama,
 one worth rewatching, and the rest your best picks.
 TV shows: choose up to {{.TargetTVShows}}.
-
+{{if .TargetBooks}}Books: choose up to {{.TargetBooks}} from the user's want-to-read shelf.
+Favor variety over the shelf's most obvious picks, and weigh the authors and
+books they already rated highly.
+{{end}}
 Rules:
-- Use only ids present in the shortlist. Do not repeat an id.
+- Use only ids present in the shortlists. Do not repeat an id.
 - Give a short, specific reason per pick.
-
+{{if not .TargetBooks}}- Return an empty books array.
+{{end}}
 {{if .Profile}}User taste profile:
 {{.Profile}}
 {{end}}{{if .Loved}}{{.Loved}}
+{{end}}{{if .Authors}}{{.Authors}}
+{{end}}{{if .LovedBooks}}{{.LovedBooks}}
 {{end}}
 Movie shortlist:
 {{.Movies}}
 
 TV shortlist:
 {{.TVShows}}
+{{if .TargetBooks}}
+Book shortlist:
+{{.Books}}
+{{end}}

--- a/lib/recommend/prompts/system.txt
+++ b/lib/recommend/prompts/system.txt
@@ -1,3 +1,5 @@
-You are a media recommendation assistant. You will be given a numbered shortlist
-of titles the user already owns. Choose the best fits for each requested slot and
-return only their IDs with a one-sentence reason each. Never invent IDs or titles.
+You are a media recommendation assistant. You will be given numbered shortlists of
+titles the user already has access to: movies and TV shows from their library, and
+books from their want-to-read shelf. Choose the best fits for each requested slot
+and return only their IDs with a one-sentence reason each. Never invent IDs or
+titles.

--- a/lib/recommend/recommend.go
+++ b/lib/recommend/recommend.go
@@ -20,6 +20,7 @@ type StatsData struct {
 	TotalRecommendations        int64
 	TotalMovies                 int64
 	TotalTVShows                int64
+	TotalBooks                  int64
 	FirstDate                   time.Time
 	LastDate                    time.Time
 	AverageDailyRecommendations float64
@@ -29,7 +30,10 @@ type StatsData struct {
 	}
 	TotalCachedMovies  int64
 	TotalCachedTVShows int64
-	LastCacheUpdate    time.Time
+	// TotalShelvedBooks is the want-to-read pool; TotalReadBooks is the taste signal.
+	TotalShelvedBooks int64
+	TotalReadBooks    int64
+	LastCacheUpdate   time.Time
 }
 
 // Recommender produces and serves daily Plex/TMDb recommendations using
@@ -151,6 +155,9 @@ func (r *Recommender) GetStats(ctx context.Context) (*StatsData, error) {
 	if err := r.db.WithContext(ctx).Model(&models.Recommendation{}).Where("type = ?", models.TypeTVShow).Count(&stats.TotalTVShows).Error; err != nil {
 		return nil, fmt.Errorf("failed to get total TV shows: %w", err)
 	}
+	if err := r.db.WithContext(ctx).Model(&models.Recommendation{}).Where("type = ?", models.TypeBook).Count(&stats.TotalBooks).Error; err != nil {
+		return nil, fmt.Errorf("failed to get total books: %w", err)
+	}
 
 	// Get date range
 	var firstDate, lastDate time.Time
@@ -210,6 +217,12 @@ func (r *Recommender) GetStats(ctx context.Context) (*StatsData, error) {
 	}
 	if err := r.db.WithContext(ctx).Model(&models.TVShow{}).Count(&stats.TotalCachedTVShows).Error; err != nil {
 		return nil, fmt.Errorf("failed to get total cached TV shows: %w", err)
+	}
+	if err := r.db.WithContext(ctx).Model(&models.Book{}).Where("shelf = ?", models.ShelfToRead).Count(&stats.TotalShelvedBooks).Error; err != nil {
+		return nil, fmt.Errorf("failed to get total shelved books: %w", err)
+	}
+	if err := r.db.WithContext(ctx).Model(&models.Book{}).Where("shelf = ?", models.ShelfRead).Count(&stats.TotalReadBooks).Error; err != nil {
+		return nil, fmt.Errorf("failed to get total read books: %w", err)
 	}
 
 	// Get last cache update time from the most recent movie or TV show update

--- a/lib/recommend/recommend_test.go
+++ b/lib/recommend/recommend_test.go
@@ -18,7 +18,7 @@ func testDB(t *testing.T) *gorm.DB {
 	t.Helper()
 	db := dbtest.New(t)
 	if err := db.AutoMigrate(
-		&models.Recommendation{}, &models.Movie{}, &models.TVShow{},
+		&models.Recommendation{}, &models.Movie{}, &models.TVShow{}, &models.Book{},
 		&models.GenerationRun{}, &models.ExternalSignal{}, &models.OAuthToken{},
 	); err != nil {
 		t.Fatal(err)

--- a/lib/recommend/signals.go
+++ b/lib/recommend/signals.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/icco/gutil/logging"
 	"github.com/icco/recommender/lib/anilist"
+	"github.com/icco/recommender/lib/goodreads"
 	"github.com/icco/recommender/lib/omdb"
 	"github.com/icco/recommender/lib/trakt"
 	"github.com/icco/recommender/models"
@@ -250,6 +251,8 @@ type SignalConfig struct {
 	OMDbAPIKey        string
 	// OMDbBatchSize caps OMDb lookups per cache run; <= 0 uses the default.
 	OMDbBatchSize int
+	// GoodreadsUserID is the numeric id from the profile URL; enables the books tier.
+	GoodreadsUserID string
 }
 
 // traktClient returns a Trakt client if credentials are configured, else nil.
@@ -275,6 +278,11 @@ func (r *Recommender) configuredSources() []SignalSource {
 			batch = defaultMetascoreBatch
 		}
 		out = append(out, &metascoreSource{db: r.db, client: omdb.NewClient(r.sigCfg.OMDbAPIKey), batch: batch})
+	}
+	if r.sigCfg.GoodreadsUserID != "" {
+		out = append(out, &goodreadsSource{
+			db: r.db, client: goodreads.NewClient(), userID: r.sigCfg.GoodreadsUserID,
+		})
 	}
 	return out
 }

--- a/lib/recommend/slotting.go
+++ b/lib/recommend/slotting.go
@@ -27,6 +27,7 @@ type pick struct {
 type pickResponse struct {
 	Movies  []pick `json:"movies"`
 	TVShows []pick `json:"tvshows"`
+	Books   []pick `json:"books"`
 }
 
 // parsePickResponse decodes the model's JSON. Unknown fields are ignored.
@@ -53,8 +54,9 @@ func pickSchema() *genai.Schema {
 		Properties: map[string]*genai.Schema{
 			"movies":  {Type: genai.TypeArray, Items: item},
 			"tvshows": {Type: genai.TypeArray, Items: item},
+			"books":   {Type: genai.TypeArray, Items: item},
 		},
-		Required: []string{"movies", "tvshows"},
+		Required: []string{"movies", "tvshows", "books"},
 	}
 }
 
@@ -71,9 +73,12 @@ func toRec(c candidate, explanation string, date time.Time) models.Recommendatio
 		Title: c.Title, Type: c.Type, Year: c.Year, Rating: c.Rating,
 		Genre: strings.Join(c.Genres, ", "), PosterURL: c.PosterURL, Runtime: c.Runtime,
 		Explanation: explanation, Date: date, Metascore: c.Metascore,
+		Author: c.Author, SourceURL: c.SourceURL,
 	}
 	// Only link titles Metacritic scored: best proxy for the slug resolving.
-	if c.Metascore != nil {
+	// Books are excluded outright — Metacritic has no book section, so a slug
+	// built from a book title would resolve to an unrelated film.
+	if c.Metascore != nil && c.Type != models.TypeBook {
 		rec.MetacriticURL = metacritic.URLFor(metacriticSection(c.Type), c.Title)
 	}
 	if c.TMDbID != nil {
@@ -86,6 +91,9 @@ func toRec(c candidate, explanation string, date time.Time) models.Recommendatio
 	case models.TypeTVShow:
 		id := c.ID
 		rec.TVShowID = &id
+	case models.TypeBook:
+		id := c.ID
+		rec.BookID = &id
 	}
 	return rec
 }
@@ -167,9 +175,13 @@ func selectMovies(picks []pick, shortlist []candidate, target int) []models.Reco
 	return out
 }
 
-// selectTVShows fills up to `target` TV slots from valid picks, padding from the
-// shortlist. All candidates here are already unwatched (loadCandidates filters).
-func selectTVShows(picks []pick, shortlist []candidate, target int) []models.Recommendation {
+// selectByType fills up to `target` slots of one type from valid picks, in the
+// order the model returned them, then pads from the ranked shortlist if the model
+// returned too few. Unknown or wrong-type IDs are ignored. Caller sets Date.
+//
+// Neither TV shows nor books use role slots the way movies do: TV candidates are
+// already filtered to unwatched, and books have no rewatch or genre roles to fill.
+func selectByType(picks []pick, shortlist []candidate, recType string, target int) []models.Recommendation {
 	byID := candByID(shortlist)
 	used := make(map[uint]bool)
 	var out []models.Recommendation
@@ -178,7 +190,7 @@ func selectTVShows(picks []pick, shortlist []candidate, target int) []models.Rec
 			break
 		}
 		c, ok := byID[p.ID]
-		if !ok || c.Type != models.TypeTVShow || used[c.ID] {
+		if !ok || c.Type != recType || used[c.ID] {
 			continue
 		}
 		used[c.ID] = true
@@ -188,11 +200,22 @@ func selectTVShows(picks []pick, shortlist []candidate, target int) []models.Rec
 		if len(out) >= target {
 			break
 		}
-		if c.Type != models.TypeTVShow || used[c.ID] {
+		if c.Type != recType || used[c.ID] {
 			continue
 		}
 		used[c.ID] = true
 		out = append(out, toRec(c, "", time.Time{}))
 	}
 	return out
+}
+
+// selectTVShows fills up to `target` TV slots. All candidates here are already
+// unwatched (loadCandidates filters).
+func selectTVShows(picks []pick, shortlist []candidate, target int) []models.Recommendation {
+	return selectByType(picks, shortlist, models.TypeTVShow, target)
+}
+
+// selectBooks fills up to `target` book slots from the Goodreads to-read shelf.
+func selectBooks(picks []pick, shortlist []candidate, target int) []models.Recommendation {
+	return selectByType(picks, shortlist, models.TypeBook, target)
 }

--- a/lib/recommend/slotting.go
+++ b/lib/recommend/slotting.go
@@ -39,7 +39,7 @@ func parsePickResponse(raw string) (pickResponse, error) {
 	return pr, nil
 }
 
-// pickSchema is the Gemini response schema: two arrays of {id, explanation}.
+// pickSchema is the Gemini response schema: three arrays of {id, explanation}.
 func pickSchema() *genai.Schema {
 	item := &genai.Schema{
 		Type: genai.TypeObject,
@@ -76,8 +76,8 @@ func toRec(c candidate, explanation string, date time.Time) models.Recommendatio
 		Author: c.Author, SourceURL: c.SourceURL,
 	}
 	// Only link titles Metacritic scored: best proxy for the slug resolving.
-	// Books are excluded outright — Metacritic has no book section, so a slug
-	// built from a book title would resolve to an unrelated film.
+	// Books are excluded — Metacritic has no book section, so the slug would
+	// resolve to an unrelated film.
 	if c.Metascore != nil && c.Type != models.TypeBook {
 		rec.MetacriticURL = metacritic.URLFor(metacriticSection(c.Type), c.Title)
 	}
@@ -175,12 +175,10 @@ func selectMovies(picks []pick, shortlist []candidate, target int) []models.Reco
 	return out
 }
 
-// selectByType fills up to `target` slots of one type from valid picks, in the
-// order the model returned them, then pads from the ranked shortlist if the model
-// returned too few. Unknown or wrong-type IDs are ignored. Caller sets Date.
-//
-// Neither TV shows nor books use role slots the way movies do: TV candidates are
-// already filtered to unwatched, and books have no rewatch or genre roles to fill.
+// selectByType fills up to `target` slots of one type from valid picks in model
+// order, padding from the ranked shortlist if the model returned too few. Unknown
+// or wrong-type IDs are ignored. Caller sets Date. Neither TV nor books use the
+// role slots movies do.
 func selectByType(picks []pick, shortlist []candidate, recType string, target int) []models.Recommendation {
 	byID := candByID(shortlist)
 	used := make(map[uint]bool)

--- a/lib/recommend/slotting_test.go
+++ b/lib/recommend/slotting_test.go
@@ -2,6 +2,7 @@ package recommend
 
 import (
 	"testing"
+	"time"
 
 	"github.com/icco/recommender/models"
 )
@@ -74,4 +75,61 @@ func findCand(cs []candidate, id uint) candidate {
 		}
 	}
 	return candidate{}
+}
+
+func TestSelectBooks_ignoresOtherTypesAndPads(t *testing.T) {
+	shortlist := []candidate{
+		{ID: 1, Type: models.TypeMovie, Title: "A Movie"},
+		{ID: 2, Type: models.TypeBook, Title: "Piranesi", Author: "Susanna Clarke", Runtime: 245},
+		{ID: 3, Type: models.TypeBook, Title: "Babel", Author: "R.F. Kuang"},
+		{ID: 4, Type: models.TypeBook, Title: "Padded In"},
+	}
+	// The movie id and an unknown id are both ignored; the third slot pads.
+	picks := []pick{{ID: 1, Explanation: "wrong type"}, {ID: 99}, {ID: 3, Explanation: "picked"}}
+
+	got := selectBooks(picks, shortlist, 3)
+	if len(got) != 3 {
+		t.Fatalf("got %d books, want 3", len(got))
+	}
+	if got[0].Title != "Babel" || got[0].Explanation != "picked" {
+		t.Errorf("first = %q/%q, want Babel/picked", got[0].Title, got[0].Explanation)
+	}
+	for _, rec := range got {
+		if rec.Type != models.TypeBook {
+			t.Errorf("%q has type %q, want book", rec.Title, rec.Type)
+		}
+		if rec.BookID == nil {
+			t.Errorf("%q has nil BookID", rec.Title)
+		}
+		if rec.MovieID != nil || rec.TVShowID != nil {
+			t.Errorf("%q set a screen-tier FK", rec.Title)
+		}
+	}
+	if got[0].Author != "R.F. Kuang" {
+		t.Errorf("Author = %q, want R.F. Kuang", got[0].Author)
+	}
+}
+
+// Metacritic has no book section, so a book must never get a metacritic.com link
+// even if a Metascore somehow reaches it.
+func TestToRec_bookNeverGetsMetacriticURL(t *testing.T) {
+	score := 90
+	rec := toRec(candidate{ID: 1, Type: models.TypeBook, Title: "Dune", Metascore: &score}, "", time.Time{})
+	if rec.MetacriticURL != "" {
+		t.Errorf("MetacriticURL = %q, want empty for a book", rec.MetacriticURL)
+	}
+	movie := toRec(candidate{ID: 2, Type: models.TypeMovie, Title: "Dune", Metascore: &score}, "", time.Time{})
+	if movie.MetacriticURL == "" {
+		t.Error("movie with a Metascore should still get a MetacriticURL")
+	}
+}
+
+func TestParsePickResponse_books(t *testing.T) {
+	pr, err := parsePickResponse(`{"movies":[],"tvshows":[],"books":[{"id":7,"explanation":"why"}]}`)
+	if err != nil {
+		t.Fatalf("parsePickResponse: %v", err)
+	}
+	if len(pr.Books) != 1 || pr.Books[0].ID != 7 || pr.Books[0].Explanation != "why" {
+		t.Errorf("Books = %+v", pr.Books)
+	}
 }

--- a/main.go
+++ b/main.go
@@ -145,6 +145,7 @@ func main() {
 		TraktClientSecret: os.Getenv("TRAKT_CLIENT_SECRET"),
 		AniListUsername:   os.Getenv("ANILIST_USERNAME"),
 		OMDbAPIKey:        os.Getenv("OMDB_API_KEY"),
+		GoodreadsUserID:   os.Getenv("GOODREADS_USER_ID"),
 	}
 	// OMDB_BATCH_SIZE caps Metacritic lookups per cache run; unset uses the
 	// default sized for OMDb's free daily quota.

--- a/models/models.go
+++ b/models/models.go
@@ -68,13 +68,10 @@ type TVShow struct {
 	Recommendations []Recommendation `gorm:"foreignKey:TVShowID"`
 }
 
-// Book represents a book on one of the user's Goodreads shelves.
-//
-// Unlike Movie and TVShow, which mirror an owned Plex library, books come from
-// Goodreads shelves: Shelf == ShelfToRead is the recommendable pool (books the
-// user already decided they want), and Shelf == ShelfRead carries the taste
-// signal in UserRating. A book moves between shelves over time, so Shelf is
-// refreshed on every sync rather than treated as immutable.
+// Book represents a book on one of the user's Goodreads shelves. ShelfToRead is
+// the recommendable pool (the books analogue of an owned Plex library);
+// ShelfRead carries the taste signal in UserRating. Shelf is refreshed on every
+// sync, since a finished book moves between the two.
 type Book struct {
 	ID          uint    `gorm:"primarykey"`
 	GoodreadsID string  `gorm:"type:varchar(32);not null;uniqueIndex:idx_books_goodreads_id"` // Goodreads book id from the shelf feed
@@ -102,9 +99,8 @@ type Book struct {
 // Recommendation represents a single recommendation item with its metadata.
 type Recommendation struct {
 	ID uint `gorm:"primarykey"`
-	// Uniqueness is per (date, type, title) rather than (date, title): a book and
-	// a film routinely share a title, and the narrower key silently dropped one
-	// of the two.
+	// Keyed on (date, type, title), not (date, title): a book and a film share a
+	// title often enough that the narrow key dropped one of them.
 	Date          time.Time `gorm:"not null;index:idx_recommendations_date;uniqueIndex:idx_recommendations_date_type_title"`                                                            // The date this recommendation was generated
 	Title         string    `gorm:"type:varchar(500);not null;index:idx_recommendations_title;uniqueIndex:idx_recommendations_date_type_title"`                                         // Title of the content
 	Type          string    `gorm:"type:varchar(20);not null;index:idx_recommendations_type;uniqueIndex:idx_recommendations_date_type_title;check:type IN ('movie', 'tvshow', 'book')"` // "movie", "tvshow", or "book"
@@ -145,10 +141,9 @@ func (r Recommendation) MetascoreValue() int {
 	return *r.Metascore
 }
 
-// GoodreadsRating converts a book's stored Rating back to Goodreads' native
-// 5-star scale. Rating is persisted on the 0-10 scale shared with movies and TV
-// so one scoring path serves all three tiers, but readers recognize the 5-star
-// number, so that is what the book cards show.
+// GoodreadsRating converts a book's Rating back to the native 5-star scale.
+// Rating persists on the 0-10 scale so one scoring path serves all three tiers,
+// but book cards show the number readers recognize.
 func (r Recommendation) GoodreadsRating() float64 {
 	return r.Rating / 2.0
 }

--- a/models/models.go
+++ b/models/models.go
@@ -11,6 +11,13 @@ import (
 const (
 	TypeMovie  = "movie"
 	TypeTVShow = "tvshow"
+	TypeBook   = "book"
+)
+
+// Goodreads shelf values used in Book.Shelf.
+const (
+	ShelfRead   = "read"
+	ShelfToRead = "to-read"
 )
 
 // Movie represents a movie from Plex
@@ -61,30 +68,68 @@ type TVShow struct {
 	Recommendations []Recommendation `gorm:"foreignKey:TVShowID"`
 }
 
+// Book represents a book on one of the user's Goodreads shelves.
+//
+// Unlike Movie and TVShow, which mirror an owned Plex library, books come from
+// Goodreads shelves: Shelf == ShelfToRead is the recommendable pool (books the
+// user already decided they want), and Shelf == ShelfRead carries the taste
+// signal in UserRating. A book moves between shelves over time, so Shelf is
+// refreshed on every sync rather than treated as immutable.
+type Book struct {
+	ID          uint    `gorm:"primarykey"`
+	GoodreadsID string  `gorm:"type:varchar(32);not null;uniqueIndex:idx_books_goodreads_id"` // Goodreads book id from the shelf feed
+	Title       string  `gorm:"type:varchar(500);not null;index:idx_books_title"`
+	Author      string  `gorm:"type:varchar(255);index:idx_books_author"`
+	Year        int     `gorm:"default:0;index:idx_books_year"`        // Publication year; 0 when the feed omits it (common on to-read)
+	Rating      float64 `gorm:"index:idx_books_rating"`                // Goodreads community average, rescaled 0-10 to match Movie/TVShow
+	UserRating  int     `gorm:"default:0;index:idx_books_user_rating"` // The user's own stars 1-5; 0 = unrated
+
+	Shelf     string     `gorm:"type:varchar(32);not null;index:idx_books_shelf"` // "read" or "to-read"
+	Genre     string     `gorm:"type:varchar(255);index:idx_books_genre"`         // Comma-joined user shelf names; usually empty, since most people don't shelve by genre
+	CoverURL  string     `gorm:"type:varchar(1000)"`                              // Public i.gr-assets.com cover; needs no token, unlike Plex thumbs
+	ISBN      string     `gorm:"type:varchar(32)"`
+	Pages     int        `gorm:"default:0"` // Page count; 0 when unknown
+	ReadAt    *time.Time `gorm:"index:idx_books_read_at"`
+	AddedAt   *time.Time `gorm:"index:idx_books_added_at"`
+	SyncedAt  time.Time  // Last time the shelf feed reported this book
+	CreatedAt time.Time
+	UpdatedAt time.Time
+
+	// Relationships
+	Recommendations []Recommendation `gorm:"foreignKey:BookID"`
+}
+
 // Recommendation represents a single recommendation item with its metadata.
 type Recommendation struct {
-	ID            uint      `gorm:"primarykey"`
-	Date          time.Time `gorm:"not null;index:idx_recommendations_date;uniqueIndex:idx_recommendations_date_title"`                    // The date this recommendation was generated
-	Title         string    `gorm:"type:varchar(500);not null;index:idx_recommendations_title;uniqueIndex:idx_recommendations_date_title"` // Title of the content
-	Type          string    `gorm:"type:varchar(20);not null;index:idx_recommendations_type;check:type IN ('movie', 'tvshow')"`            // "movie" or "tvshow"
-	Year          int       `gorm:"not null;index:idx_recommendations_year"`                                                               // Release year
-	Rating        float64   `gorm:"index:idx_recommendations_rating"`                                                                      // Rating (e.g., from IMDB)
-	Genre         string    `gorm:"type:varchar(255);index:idx_recommendations_genre"`                                                     // Genre(s)
-	PosterURL     string    `gorm:"type:varchar(1000)"`                                                                                    // URL to the poster image
-	Explanation   string    `gorm:"type:varchar(1000)"`                                                                                    // model's one-line reason for this pick
-	Metascore     *int      `gorm:"index:idx_recommendations_metascore"`                                                                   // Metacritic critic score 0-100 at generation time; nil = none
-	MetacriticURL string    `gorm:"type:varchar(500)"`                                                                                     // metacritic.com page for this title; "" when no Metascore
-	Runtime       int       `gorm:"default:0"`                                                                                             // Runtime in minutes (for movies) or seasons (for TV shows)
-	MovieID       *uint     `gorm:"index:idx_recommendations_movie_id;constraint:OnDelete:CASCADE"`                                        // Reference to Movie if Type is "movie"
-	TVShowID      *uint     `gorm:"index:idx_recommendations_tvshow_id;constraint:OnDelete:CASCADE"`                                       // Reference to TVShow if Type is "tvshow"
-	TMDbID        int       `gorm:"not null;index:idx_recommendations_tmdb_id"`                                                            // The Movie Database ID
-	ViewCount     int       `gorm:"-"`                                                                                                     // Plex views when building prompts only (not stored)
+	ID uint `gorm:"primarykey"`
+	// Uniqueness is per (date, type, title) rather than (date, title): a book and
+	// a film routinely share a title, and the narrower key silently dropped one
+	// of the two.
+	Date          time.Time `gorm:"not null;index:idx_recommendations_date;uniqueIndex:idx_recommendations_date_type_title"`                                                            // The date this recommendation was generated
+	Title         string    `gorm:"type:varchar(500);not null;index:idx_recommendations_title;uniqueIndex:idx_recommendations_date_type_title"`                                         // Title of the content
+	Type          string    `gorm:"type:varchar(20);not null;index:idx_recommendations_type;uniqueIndex:idx_recommendations_date_type_title;check:type IN ('movie', 'tvshow', 'book')"` // "movie", "tvshow", or "book"
+	Year          int       `gorm:"not null;index:idx_recommendations_year"`                                                                                                            // Release year
+	Rating        float64   `gorm:"index:idx_recommendations_rating"`                                                                                                                   // Rating (e.g., from IMDB)
+	Genre         string    `gorm:"type:varchar(255);index:idx_recommendations_genre"`                                                                                                  // Genre(s)
+	PosterURL     string    `gorm:"type:varchar(1000)"`                                                                                                                                 // URL to the poster image
+	Explanation   string    `gorm:"type:varchar(1000)"`                                                                                                                                 // model's one-line reason for this pick
+	Metascore     *int      `gorm:"index:idx_recommendations_metascore"`                                                                                                                // Metacritic critic score 0-100 at generation time; nil = none
+	MetacriticURL string    `gorm:"type:varchar(500)"`                                                                                                                                  // metacritic.com page for this title; "" when no Metascore
+	Runtime       int       `gorm:"default:0"`                                                                                                                                          // Minutes (movies), seasons (TV shows), or pages (books)
+	Author        string    `gorm:"type:varchar(255)"`                                                                                                                                  // Book author; "" for movies and TV shows
+	SourceURL     string    `gorm:"type:varchar(500)"`                                                                                                                                  // Canonical page for the title (goodreads.com for books); "" when none
+	MovieID       *uint     `gorm:"index:idx_recommendations_movie_id;constraint:OnDelete:CASCADE"`                                                                                     // Reference to Movie if Type is "movie"
+	TVShowID      *uint     `gorm:"index:idx_recommendations_tvshow_id;constraint:OnDelete:CASCADE"`                                                                                    // Reference to TVShow if Type is "tvshow"
+	BookID        *uint     `gorm:"index:idx_recommendations_book_id;constraint:OnDelete:CASCADE"`                                                                                      // Reference to Book if Type is "book"
+	TMDbID        int       `gorm:"not null;index:idx_recommendations_tmdb_id"`                                                                                                         // The Movie Database ID
+	ViewCount     int       `gorm:"-"`                                                                                                                                                  // Plex views when building prompts only (not stored)
 	CreatedAt     time.Time
 	UpdatedAt     time.Time
 
 	// Relationships
 	Movie  *Movie  `gorm:"foreignKey:MovieID"`
 	TVShow *TVShow `gorm:"foreignKey:TVShowID"`
+	Book   *Book   `gorm:"foreignKey:BookID"`
 }
 
 // HasMetascore reports whether Metacritic scored this title. Templates use this
@@ -100,6 +145,14 @@ func (r Recommendation) MetascoreValue() int {
 	return *r.Metascore
 }
 
+// GoodreadsRating converts a book's stored Rating back to Goodreads' native
+// 5-star scale. Rating is persisted on the 0-10 scale shared with movies and TV
+// so one scoring path serves all three tiers, but readers recognize the 5-star
+// number, so that is what the book cards show.
+func (r Recommendation) GoodreadsRating() float64 {
+	return r.Rating / 2.0
+}
+
 // Run status values for GenerationRun.Status.
 const (
 	RunStatusOK    = "ok"
@@ -112,6 +165,7 @@ const (
 	SourceTrakt         = "trakt"
 	SourceAniList       = "anilist"
 	SourceOMDb          = "omdb"
+	SourceGoodreads     = "goodreads"
 	SignalKindWatched   = "watched"
 	SignalKindRated     = "rated"
 	SignalKindScore     = "score"
@@ -125,6 +179,7 @@ type GenerationRun struct {
 	Status      string    `gorm:"type:varchar(20);not null"`               // "ok" or "error"
 	MovieCount  int       `gorm:"default:0"`
 	TVShowCount int       `gorm:"default:0"`
+	BookCount   int       `gorm:"default:0"`
 	Model       string    `gorm:"type:varchar(64)"`
 	DurationMS  int64     `gorm:"default:0"`
 	Error       string    `gorm:"type:varchar(1000)"`

--- a/template.env
+++ b/template.env
@@ -39,3 +39,5 @@ ANILIST_USERNAME=
 OMDB_API_KEY=
 # OMDb lookups per cache run; blank uses 40, sized for the free 1000/day quota
 OMDB_BATCH_SIZE=
+# Books tier: numeric id from goodreads.com/user/show/<id>-name (NOT an author id)
+GOODREADS_USER_ID=


### PR DESCRIPTION
Adds a books tier: 4 movies + 3 TV + 3 books daily, from the Goodreads want-to-read shelf.

## Source

Goodreads retired its API in Dec 2020 and issues no new keys, so `lib/goodreads` reads the per-shelf RSS feed — no key, no auth, no new deps. The existing Go clients are dead ends: `KyleBanks/goodreads` and friends target the retired API; `ahobsonsayers/abs-tract` uses a borrowed hardcoded key and can't read user shelves at all.

## Design

- **`to-read` is the candidate pool**, preserving the "only recommend what you already have" invariant Plex ownership gives movies and TV. Real IDs to slot by, real covers, nothing invented.
- **Author affinity, not genre.** The feed has no genre field, only the user's own shelf names — 4 of 100 read books on my profile. Read-shelf stars are rich by contrast, so affinity keys on author.
- **Fails soft.** Unset `GOODREADS_USER_ID` or unreachable Goodreads costs the books tier only. `TargetBooks` collapses to 0 and the prompt drops its books section.

## Migrations

Two that break silently otherwise:

- **`recommendations.type` CHECK** widened to include `'book'` *before* AutoMigrate — GORM emits a CHECK only when creating the column and never reconciles a changed one, so an existing DB rejects every book insert. Found by scanning `pg_constraint`; the generated name isn't guaranteed.
- **`(date, title)` → `(date, type, title)`.** A book and a film share a title often enough (Dune) that the narrow key dropped one.

Plus the `books` table, `Recommendation.BookID`/`Author`/`SourceURL`, `GenerationRun.BookCount`.

## Testing

- ✅ Full suite + lint clean
- ✅ New tests: RSS parsing, absent fields, page walking, ignored page param, 404, truncation, shelf sync, shelf moves, partial failure, batching, author affinity, candidate loading, slotting, book card, both migrations
- ✅ Live check against the real profile: 1749 to-read (all with covers, 1715 with page counts), 1131 read with 1112 rated

At that shelf size a round trip per row would eat the shared cron budget, so upserts batch. A shelf past `maxPages` returns `ErrTruncated` with partial results rather than passing as complete.

## Config

`GOODREADS_USER_ID` — the number in `goodreads.com/user/show/<id>-name`. **Not** the author id from `/author/show/<id>`; that returns a different person's shelves with no error. Set on mist in icco/icco.me#201.