### PR TITLE
refactor: use recentExclusionDays for the movie/TV pool too

### DIFF
--- a/lib/recommend/candidates.go
+++ b/lib/recommend/candidates.go
@@ -152,7 +152,7 @@ func formatBookShortlist(cands []candidate) string {
 // loadCandidates loads eligible movies and TV shows, excluding titles recommended
 // in the last 30 days. TV is restricted to unwatched shows.
 func (r *Recommender) loadCandidates(ctx context.Context, date time.Time) (movies, tvshows []candidate, err error) {
-	excludeMovies, excludeTV, err := r.recentlyRecommendedIDs(ctx, date, 30)
+	excludeMovies, excludeTV, err := r.recentlyRecommendedIDs(ctx, date, recentExclusionDays)
 	if err != nil {
 		return nil, nil, err
 	}


### PR DESCRIPTION
The 30-day exclusion window was written twice after #113 — as a constant for books and a literal for movies/TV. One constant now.

Raced the #113 squash merge; no behavior change.