### PR TITLE
fix: drop TMDB_API_KEY from template.env

### DIFF
--- a/template.env
+++ b/template.env
@@ -8,9 +8,6 @@ POSTGRES_DB=recommender
 # Directory for locally cached Plex posters
 POSTER_DIR=posters
 
-# API Keys
-TMDB_API_KEY=your-tmdb-api-key
-
 # Plex configuration
 PLEX_TOKEN=your-plex-token
 PLEX_URL=http://your-plex-server:32400


### PR DESCRIPTION
Follow-up to #116, which deleted the TMDb client. `template.env` still advertises `TMDB_API_KEY`, so a fresh local setup is told to obtain a credential nothing reads.

This was fixed on #116's branch — it's the Copilot review comment on that PR — but the squash merge took only the first commit, so it never landed.

Also removes the now-empty `# API Keys` header it sat under; the remaining keys are grouped by service.