### PR TITLE
fix(plex): fix cache upsert failing when Plex reassigns a rating key

### DIFF
--- a/lib/plex/client.go
+++ b/lib/plex/client.go
@@ -5,6 +5,7 @@ package plex
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -18,6 +19,7 @@ import (
 	"github.com/LukeHagar/plexgo/models/components"
 	"github.com/icco/gutil/logging"
 	"github.com/icco/recommender/models"
+	"github.com/jackc/pgx/v5/pgconn"
 	"go.uber.org/zap"
 	"gorm.io/gorm"
 	"gorm.io/gorm/clause"
@@ -620,6 +622,16 @@ var tvUpsertColumns = []string{
 	"tm_db_id", "im_db_id", "tv_db_id", "enriched_at", "view_count", "updated_at",
 }
 
+// isUniqueViolation reports whether err is a Postgres unique-violation on the
+// named constraint.
+func isUniqueViolation(err error, constraint string) bool {
+	var pgErr *pgconn.PgError
+	if !errors.As(err, &pgErr) {
+		return false
+	}
+	return pgErr.Code == "23505" && pgErr.ConstraintName == constraint
+}
+
 // upsertMovieBatch upserts movies by plex_rating_key in a single transaction.
 func (c *Client) upsertMovieBatch(ctx context.Context, movies []Item) error {
 	return c.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
@@ -675,10 +687,37 @@ func (c *Client) upsertMovieBatch(ctx context.Context, movies []Item) error {
 				UpdatedAt:     now,
 			}
 
+			if err := tx.SavePoint("upsert_movie").Error; err != nil {
+				return fmt.Errorf("failed to create savepoint for movie %q: %w", item.Title, err)
+			}
 			if err := tx.Clauses(clause.OnConflict{
 				Columns:   []clause.Column{{Name: "plex_rating_key"}},
 				DoUpdates: clause.AssignmentColumns(movieUpsertColumns),
 			}).Create(&movie).Error; err != nil {
+				// A reused tmdb_id (Plex reassigned the rating key) hits
+				// idx_movies_tmdb_id since ON CONFLICT only covers
+				// plex_rating_key; roll back to the savepoint (Postgres
+				// aborts the transaction on error) and update by tmdb_id.
+				if tmdbID != nil && isUniqueViolation(err, "idx_movies_tmdb_id") &&
+					tx.RollbackTo("upsert_movie").Error == nil {
+					res := tx.Model(&models.Movie{}).Where("tm_db_id = ?", *tmdbID).Updates(map[string]any{
+						"plex_rating_key": movie.PlexRatingKey,
+						titleKey:          movie.Title,
+						"year":            movie.Year,
+						"rating":          movie.Rating,
+						"genre":           movie.Genre,
+						"poster_url":      movie.PosterURL,
+						"runtime":         movie.Runtime,
+						"im_db_id":        movie.IMDbID,
+						"tv_db_id":        movie.TVDbID,
+						"enriched_at":     movie.EnrichedAt,
+						"view_count":      movie.ViewCount,
+						"updated_at":      movie.UpdatedAt,
+					})
+					if res.Error == nil && res.RowsAffected > 0 {
+						continue
+					}
+				}
 				return fmt.Errorf("failed to upsert movie %q: %w", item.Title, err)
 			}
 		}
@@ -741,10 +780,34 @@ func (c *Client) upsertTVShowBatch(ctx context.Context, shows []Item) error {
 				UpdatedAt:     now,
 			}
 
+			if err := tx.SavePoint("upsert_tvshow").Error; err != nil {
+				return fmt.Errorf("failed to create savepoint for TV show %q: %w", item.Title, err)
+			}
 			if err := tx.Clauses(clause.OnConflict{
 				Columns:   []clause.Column{{Name: "plex_rating_key"}},
 				DoUpdates: clause.AssignmentColumns(tvUpsertColumns),
 			}).Create(&tvShow).Error; err != nil {
+				// See the matching comment in upsertMovieBatch.
+				if tmdbID != nil && isUniqueViolation(err, "idx_tvshows_tmdb_id") &&
+					tx.RollbackTo("upsert_tvshow").Error == nil {
+					res := tx.Model(&models.TVShow{}).Where("tm_db_id = ?", *tmdbID).Updates(map[string]any{
+						"plex_rating_key": tvShow.PlexRatingKey,
+						titleKey:          tvShow.Title,
+						"year":            tvShow.Year,
+						"rating":          tvShow.Rating,
+						"genre":           tvShow.Genre,
+						"poster_url":      tvShow.PosterURL,
+						"seasons":         tvShow.Seasons,
+						"im_db_id":        tvShow.IMDbID,
+						"tv_db_id":        tvShow.TVDbID,
+						"enriched_at":     tvShow.EnrichedAt,
+						"view_count":      tvShow.ViewCount,
+						"updated_at":      tvShow.UpdatedAt,
+					})
+					if res.Error == nil && res.RowsAffected > 0 {
+						continue
+					}
+				}
 				return fmt.Errorf("failed to upsert TV show %q: %w", item.Title, err)
 			}
 		}

--- a/lib/plex/client_cache_test.go
+++ b/lib/plex/client_cache_test.go
@@ -60,6 +60,94 @@ func TestUpsertMovieBatch_updatesSameRow(t *testing.T) {
 	}
 }
 
+// TestUpsertMovieBatch_reassignedRatingKey covers Plex reusing a tmdb_id
+// under a new rating key, which used to fail the whole batch.
+func TestUpsertMovieBatch_reassignedRatingKey(t *testing.T) {
+	db := testPlexDB(t)
+	c := &Client{
+		plexURL: "http://localhost:32400",
+		db:      db,
+	}
+	ctx := t.Context()
+
+	v1 := []Item{{RatingKey: "501", Key: "/m/501", Title: "Alpha", Type: models.TypeMovie, AddedAt: 1, Guids: []string{"tmdb://603"}}}
+	if err := c.upsertMovieBatch(ctx, v1); err != nil {
+		t.Fatal(err)
+	}
+	var id1 uint
+	if err := db.Model(&models.Movie{}).Where("plex_rating_key = ?", "501").Select("id").Scan(&id1).Error; err != nil || id1 == 0 {
+		t.Fatalf("first insert id=%d err=%v", id1, err)
+	}
+
+	v2 := []Item{{RatingKey: "999", Key: "/m/999", Title: "Alpha Remastered", Type: models.TypeMovie, AddedAt: 2, Guids: []string{"tmdb://603"}}}
+	if err := c.upsertMovieBatch(ctx, v2); err != nil {
+		t.Fatalf("upsert with reassigned rating key: %v", err)
+	}
+
+	var n int64
+	if err := db.Model(&models.Movie{}).Count(&n).Error; err != nil {
+		t.Fatal(err)
+	}
+	if n != 1 {
+		t.Fatalf("movie count = %d want 1", n)
+	}
+	row := struct {
+		ID            uint
+		Title         string
+		PlexRatingKey string
+	}{}
+	if err := db.Model(&models.Movie{}).Take(&row).Error; err != nil {
+		t.Fatal(err)
+	}
+	if row.ID != id1 || row.Title != "Alpha Remastered" || row.PlexRatingKey != "999" {
+		t.Fatalf("got %+v, want id=%d title=Alpha Remastered plex_rating_key=999", row, id1)
+	}
+}
+
+// TestUpsertTVShowBatch_reassignedRatingKey mirrors
+// TestUpsertMovieBatch_reassignedRatingKey for the TV show upsert path.
+func TestUpsertTVShowBatch_reassignedRatingKey(t *testing.T) {
+	db := testPlexDB(t)
+	c := &Client{
+		plexURL: "http://localhost:32400",
+		db:      db,
+	}
+	ctx := t.Context()
+
+	v1 := []Item{{RatingKey: "701", Key: "/s/701", Title: "Gamma", Type: models.TypeTVShow, AddedAt: 1, Guids: []string{"tmdb://1399"}}}
+	if err := c.upsertTVShowBatch(ctx, v1); err != nil {
+		t.Fatal(err)
+	}
+	var id1 uint
+	if err := db.Model(&models.TVShow{}).Where("plex_rating_key = ?", "701").Select("id").Scan(&id1).Error; err != nil || id1 == 0 {
+		t.Fatalf("first insert id=%d err=%v", id1, err)
+	}
+
+	v2 := []Item{{RatingKey: "888", Key: "/s/888", Title: "Gamma Remastered", Type: models.TypeTVShow, AddedAt: 2, Guids: []string{"tmdb://1399"}}}
+	if err := c.upsertTVShowBatch(ctx, v2); err != nil {
+		t.Fatalf("upsert with reassigned rating key: %v", err)
+	}
+
+	var n int64
+	if err := db.Model(&models.TVShow{}).Count(&n).Error; err != nil {
+		t.Fatal(err)
+	}
+	if n != 1 {
+		t.Fatalf("tv show count = %d want 1", n)
+	}
+	row := struct {
+		ID            uint
+		Title         string
+		PlexRatingKey string
+	}{}
+	if err := db.Model(&models.TVShow{}).Take(&row).Error; err != nil {
+		t.Fatal(err)
+	}
+	if row.ID != id1 || row.Title != "Gamma Remastered" || row.PlexRatingKey != "888" {
+		t.Fatalf("got %+v, want id=%d title=\"Gamma Remastered\" plex_rating_key=888", row, id1)
+	}
+}
+
 func TestRemoveMoviesNotInSnapshot_clearsRecFK(t *testing.T) {
 	db := testPlexDB(t)
 	c := &Client{


### PR DESCRIPTION
`ON CONFLICT (plex_rating_key)` doesn't cover `tm_db_id`, which is also unique. When Plex reassigns a rating key to a title already cached under a different one, the insert hits `idx_movies_tmdb_id`/`idx_tvshows_tmdb_id` instead and fails the whole batch:

```
ERROR: duplicate key value violates unique constraint "idx_movies_tmdb_id" (SQLSTATE 23505)
```

Fix: on that specific unique-violation, roll back to a per-item savepoint and update the row already keyed by `tm_db_id` instead of inserting a duplicate.

## Test plan
- [x] Added regression tests reproducing the production error, passing after the fix
- [x] `go test ./...`, `go build ./...`, `go vet ./...`